### PR TITLE
Ensure the host can be parsed as an IPv6 address.

### DIFF
--- a/boring/src/ssl/connector.rs
+++ b/boring/src/ssl/connector.rs
@@ -40,7 +40,7 @@ fn ctx(method: SslMethod) -> Result<SslContextBuilder, ErrorStack> {
     // This is quite a useful optimization for saving memory, but historically
     // caused CVEs in OpenSSL pre-1.0.1h, according to
     // https://bugs.python.org/issue25672
-    if version::number() >= 0x1_00_01_08_0 {
+    if version::number() >= 0x1000_1080 {
         mode |= SslMode::RELEASE_BUFFERS;
     }
 


### PR DESCRIPTION
If the host is an IPv6 address, the value returned by `Uri::host()` will [include the surrounding brackets](https://github.com/hyperium/http/pull/292). This causes boring to fail to parse the host as an [IP address](https://github.com/cloudflare/boring/blob/5cb8947d7ec6e0c67fa40167940f313b8d6537f8/boring/src/ssl/connector.rs#L342). Eventually, this causes hostname verification to fail. I _assume_ the hostname verification failure is due to the fact that the host will be compared with the `DNSName`s from `SubjectAlternativeName`, instead of the `IPAddress`es ([`set_ip` vs `set_host`](https://github.com/cloudflare/boring/blob/5cb8947d7ec6e0c67fa40167940f313b8d6537f8/boring/src/ssl/connector.rs#L341-L342)).