### PR TITLE
Include .asm files required for Windows

### DIFF
--- a/boring-sys/Cargo.toml
+++ b/boring-sys/Cargo.toml
@@ -16,6 +16,7 @@ include = [
     "/*.toml",
     "/LICENSE-MIT",
     "/deps/boringssl/**/*.[chS]",
+    "/deps/boringssl/**/*.asm",
     "/deps/boringssl/src/**/*.cc",
     "/deps/boringssl/**/CMakeLists.txt",
     "/deps/boringssl/**/sources.cmake",


### PR DESCRIPTION
When this crate is used as a dependency on Windows, boring-sys fails to build because Cargo doesn't include .asm files.

This problem was previously seen in [quiche](https://github.com/cloudflare/quiche/pull/776).