### PR TITLE
Tweak yet again the boring error reporting

### DIFF
--- a/boring/src/error.rs
+++ b/boring/src/error.rs
@@ -60,16 +60,16 @@ impl ErrorStack {
 impl fmt::Display for ErrorStack {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         if self.0.is_empty() {
-            return fmt.write_str("OpenSSL error");
+            return fmt.write_str("unknown OpenSSL error");
         }
 
         let mut first = true;
         for err in &self.0 {
             if !first {
-                fmt.write_str("\n--\n")?;
+                fmt.write_str(" ")?;
             }
-            write!(fmt, "{}", err)?;
             first = false;
+            write!(fmt, "[{}]", err.reason().unwrap_or("unknown reason"))?;
         }
         Ok(())
     }

--- a/boring/src/error.rs
+++ b/boring/src/error.rs
@@ -60,7 +60,7 @@ impl ErrorStack {
 impl fmt::Display for ErrorStack {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         if self.0.is_empty() {
-            return fmt.write_str("unknown OpenSSL error");
+            return fmt.write_str("unknown BoringSSL error");
         }
 
         let mut first = true;

--- a/boring/src/ssl/error.rs
+++ b/boring/src/ssl/error.rs
@@ -154,7 +154,7 @@ impl<S> fmt::Display for HandshakeError<S> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             HandshakeError::SetupFailure(ref e) => {
-                write!(f, "TLS stream setup failed:\n\n{}", e)
+                write!(f, "TLS stream setup failed {}", e)
             }
             HandshakeError::Failure(ref s) => fmt_mid_handshake_error(s, f, "TLS handshake failed"),
             HandshakeError::WouldBlock(ref s) => {
@@ -179,9 +179,7 @@ fn fmt_mid_handshake_error(
     }
 
     if let Some(error) = s.error().ssl_error() {
-        for error in error.errors() {
-            write!(f, " [{}]", error.reason().unwrap_or("unknown error"),)?;
-        }
+        write!(f, " {}", error)?;
     }
 
     Ok(())

--- a/boring/src/ssl/error.rs
+++ b/boring/src/ssl/error.rs
@@ -110,7 +110,7 @@ impl fmt::Display for Error {
             },
             ErrorCode::SSL => match self.ssl_error() {
                 Some(e) => write!(fmt, "{}", e),
-                None => fmt.write_str("OpenSSL error"),
+                None => fmt.write_str("unknown BoringSSL error"),
             },
             ErrorCode(code) => write!(fmt, "unknown error code {}", code),
         }
@@ -174,15 +174,7 @@ fn fmt_mid_handshake_error(
         verify => write!(f, "{}: cert verification failed - {}", prefix, verify)?,
     }
 
-    if let Some(error) = s.error().io_error() {
-        return write!(f, " ({})", error);
-    }
-
-    if let Some(error) = s.error().ssl_error() {
-        write!(f, " {}", error)?;
-    }
-
-    Ok(())
+    write!(f, " {}", s.error())
 }
 
 impl<S> From<ErrorStack> for HandshakeError<S> {


### PR DESCRIPTION
We also omit file and line in `ErrorStack` itself now too.

`ErrorStack` is the wrapped error type returned by `hyper_boring::HttpsConnector::call`.