### PR TITLE
Support for building with fips support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           path: target
           key: clippy-target-${{ runner.os }}-${{ steps.rust-version.outputs.version }}-${{ hashFiles('Cargo.lock') }}
       - name: Run clippy
-        run: cargo clippy --all --all-targets
+        run: cargo clippy --all --all-targets -- -A clippy::upper_case_acronyms
   test:
     name: Test
     runs-on: ${{ matrix.os }}

--- a/boring-sys/Cargo.toml
+++ b/boring-sys/Cargo.toml
@@ -26,6 +26,9 @@ include = [
     "/src",
 ]
 
+[features]
+fips = []
+
 [build-dependencies]
 bindgen = "0.59"
 cmake = "0.1"

--- a/boring-sys/build.rs
+++ b/boring-sys/build.rs
@@ -200,14 +200,12 @@ fn main() {
             cfg.cxxflag("-DBORINGSSL_UNSAFE_DETERMINISTIC_MODE")
                 .cxxflag("-DBORINGSSL_UNSAFE_FUZZER_MODE");
         }
-        
         if cfg!(feature = "fips") {
             cfg.define("FIPS", "1");
         }
 
         cfg.build_target("bssl").build().display().to_string()
     });
-
 
     let build_path = get_boringssl_platform_output_path();
     let build_dir = format!("{}/build/{}", bssl_dir, build_path);

--- a/boring-sys/build.rs
+++ b/boring-sys/build.rs
@@ -208,9 +208,15 @@ fn main() {
     });
 
     let build_path = get_boringssl_platform_output_path();
-    let build_dir = format!("{}/build/{}", bssl_dir, build_path);
-    println!("cargo:rustc-link-search=native={}/crypto", build_dir);
-    println!("cargo:rustc-link-search=native={}/ssl", build_dir);
+    let build_dir = PathBuf::from(format!("{}/build/{}", bssl_dir, build_path));
+    println!(
+        "cargo:rustc-link-search=native={}",
+        build_dir.join("crypto").to_str().unwrap()
+    );
+    println!(
+        "cargo:rustc-link-search=native={}",
+        build_dir.join("ssl").to_str().unwrap()
+    );
 
     println!("cargo:rustc-link-lib=static=crypto");
     println!("cargo:rustc-link-lib=static=ssl");

--- a/boring-sys/build.rs
+++ b/boring-sys/build.rs
@@ -208,7 +208,7 @@ fn main() {
     });
 
     let build_path = get_boringssl_platform_output_path();
-    let build_dir = PathBuf::from(format!("{}/build/{}", bssl_dir, build_path));
+    let build_dir = bssl_dir.join("build").join(build_path);
     println!(
         "cargo:rustc-link-search=native={}",
         build_dir.join("crypto").to_str().unwrap()

--- a/boring-sys/build.rs
+++ b/boring-sys/build.rs
@@ -93,7 +93,7 @@ fn get_boringssl_cmake_config() -> cmake::Config {
     let os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
     let pwd = std::env::current_dir().unwrap();
 
-    let mut boringssl_cmake = cmake::Config::new("deps/boringssl");
+    let mut boringssl_cmake = cmake::Config::new("deps/boringssl/src");
 
     // Add platform-specific parameters.
     match os.as_ref() {
@@ -200,13 +200,19 @@ fn main() {
             cfg.cxxflag("-DBORINGSSL_UNSAFE_DETERMINISTIC_MODE")
                 .cxxflag("-DBORINGSSL_UNSAFE_FUZZER_MODE");
         }
+        
+        if cfg!(feature = "fips") {
+            cfg.define("FIPS", "1");
+        }
 
         cfg.build_target("bssl").build().display().to_string()
     });
 
+
     let build_path = get_boringssl_platform_output_path();
     let build_dir = format!("{}/build/{}", bssl_dir, build_path);
-    println!("cargo:rustc-link-search=native={}", build_dir);
+    println!("cargo:rustc-link-search=native={}/crypto", build_dir);
+    println!("cargo:rustc-link-search=native={}/ssl", build_dir);
 
     println!("cargo:rustc-link-lib=static=crypto");
     println!("cargo:rustc-link-lib=static=ssl");

--- a/boring-sys/build.rs
+++ b/boring-sys/build.rs
@@ -208,7 +208,7 @@ fn main() {
     });
 
     let build_path = get_boringssl_platform_output_path();
-    let build_dir = bssl_dir.join("build").join(build_path);
+    let build_dir = Path::new(&bssl_dir).join("build").join(build_path);
     println!(
         "cargo:rustc-link-search=native={}",
         build_dir.join("crypto").to_str().unwrap()

--- a/boring/Cargo.toml
+++ b/boring/Cargo.toml
@@ -11,6 +11,9 @@ keywords = ["crypto", "tls", "ssl", "dtls"]
 categories = ["cryptography", "api-bindings"]
 edition = "2018"
 
+[features]
+fips = ["boring-sys/fips"]
+
 [dependencies]
 bitflags = "1.0"
 foreign-types = "0.5"

--- a/boring/src/ssl/error.rs
+++ b/boring/src/ssl/error.rs
@@ -153,9 +153,7 @@ impl<S: fmt::Debug> StdError for HandshakeError<S> {
 impl<S> fmt::Display for HandshakeError<S> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            HandshakeError::SetupFailure(ref e) => {
-                write!(f, "TLS stream setup failed {}", e)
-            }
+            HandshakeError::SetupFailure(ref e) => write!(f, "TLS stream setup failed {}", e),
             HandshakeError::Failure(ref s) => fmt_mid_handshake_error(s, f, "TLS handshake failed"),
             HandshakeError::WouldBlock(ref s) => {
                 fmt_mid_handshake_error(s, f, "TLS handshake interrupted")


### PR DESCRIPTION
Passes the FIPS=1 value into cmake to build the library in FIPS mode.
https://boringssl.googlesource.com/boringssl/+/fed35d32245ee4563691d21f55c12b4f8dac840a/crypto/fipsmodule/FIPS.md

Since the top level cmake file does not accept the fips variable we need
to point the build towards the cmake file in the src directory and
update the search paths for the crypto and ssl libraries respectively.


issue: https://github.com/cloudflare/boring/issues/8