### PR TITLE
Allow pre-built binaries of BoringSSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,27 @@
 
 [![crates.io](https://img.shields.io/crates/v/boring.svg)](https://crates.io/crates/boring)
 
-BoringSSL bindings for the Rust programming language and TLS adapters for [tokio](https://github.com/tokio-rs/tokio) 
+BoringSSL bindings for the Rust programming language and TLS adapters for [tokio](https://github.com/tokio-rs/tokio)
 and [hyper](https://github.com/hyperium/hyper) built on top of it.
 
 [Documentation](https://docs.rs/boring).
 
 ## Release Support
 
-The crate statically links with the latest BoringSSL master branch.
+By default, the crate statically links with the latest BoringSSL master branch.
 
-### Contribution
+## Support for pre-built binaries
+
+While this crate can build BoringSSL on its own, you may want to provide pre-built binaries instead.
+To do so, specify the environment variable `BORING_BSSL_PATH` with the path to the binaries.
+
+You can also provide specific headers by setting `BORING_BSSL_INCLUDE_PATH`.
+
+_Notes_: The crate will look for headers in the `$BORING_BSSL_INCLUDE_PATH/openssl/` folder, make sure to place your headers there.
+
+_Warning_: When providing a different version of BoringSSL make sure to use a compatible one, the crate relies on the presence of certain functions.
+
+## Contribution
 
 Unless you explicitly state otherwise, any contribution intentionally
 submitted for inclusion in the work by you, as defined in the Apache-2.0

--- a/boring-sys/build.rs
+++ b/boring-sys/build.rs
@@ -200,7 +200,7 @@ fn main() {
 
     let include_path = PathBuf::from(
         std::env::var("BORING_BSSL_INCLUDE_PATH")
-            .unwrap_or(String::from("deps/boringssl/src/include")),
+            .unwrap_or_else(|_| String::from("deps/boringssl/src/include")),
     );
 
     let mut builder = bindgen::Builder::default()

--- a/boring-sys/build.rs
+++ b/boring-sys/build.rs
@@ -175,14 +175,17 @@ fn main() {
     use std::env;
     use std::path::PathBuf;
 
-    let mut cfg = get_boringssl_cmake_config();
+    let bssl_dir = std::env::var("BORING_BSSL_PATH").unwrap_or_else(|_| {
+        let mut cfg = get_boringssl_cmake_config();
 
-    if cfg!(feature = "fuzzing") {
-        cfg.cxxflag("-DBORINGSSL_UNSAFE_DETERMINISTIC_MODE")
-            .cxxflag("-DBORINGSSL_UNSAFE_FUZZER_MODE");
-    }
+        if cfg!(feature = "fuzzing") {
+            cfg.cxxflag("-DBORINGSSL_UNSAFE_DETERMINISTIC_MODE")
+                .cxxflag("-DBORINGSSL_UNSAFE_FUZZER_MODE");
+        }
 
-    let bssl_dir = cfg.build_target("bssl").build().display().to_string();
+        cfg.build_target("bssl").build().display().to_string()
+    });
+
     let build_path = get_boringssl_platform_output_path();
     let build_dir = format!("{}/build/{}", bssl_dir, build_path);
     println!("cargo:rustc-link-search=native={}", build_dir);
@@ -195,7 +198,11 @@ fn main() {
         println!("cargo:rustc-cdylib-link-arg=-Wl,-undefined,dynamic_lookup");
     }
 
-    let include_path = PathBuf::from("deps/boringssl/src/include");
+    let include_path = PathBuf::from(
+        std::env::var("BORING_BSSL_INCLUDE_PATH")
+            .unwrap_or(String::from("deps/boringssl/src/include")),
+    );
+
     let mut builder = bindgen::Builder::default()
         .derive_copy(true)
         .derive_debug(true)


### PR DESCRIPTION
Following this [issue](https://github.com/cloudflare/boring/issues/36).