### PR TITLE
Fetch git submodule automatically

### DIFF
--- a/boring-sys/build.rs
+++ b/boring-sys/build.rs
@@ -173,7 +173,25 @@ fn get_boringssl_cmake_config() -> cmake::Config {
 
 fn main() {
     use std::env;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+
+    if !Path::new("deps/boringssl/CMakeLists.txt").exists() {
+        println!("cargo:warning=fetching boringssl git submodule");
+        // fetch the boringssl submodule
+        let status = Command::new("git")
+            .args(&[
+                "submodule",
+                "update",
+                "--init",
+                "--recursive",
+                "deps/boringssl",
+            ])
+            .status();
+        if !status.map_or(false, |status| status.success()) {
+            panic!("failed to fetch submodule - consider running `git submodule update --init --recursive deps/boringssl` yourself");
+        }
+    }
 
     let mut cfg = get_boringssl_cmake_config();
 


### PR DESCRIPTION
Example output:

```
$ cargo check
   Compiling boring-sys v1.1.1 (/home/jnelson/src/boring/boring-sys)
warning: fetching boringssl git submodule
    Finished dev [unoptimized + debuginfo] target(s) in 28.27s
```

Fixes https://github.com/cloudflare/boring/issues/3, closes https://github.com/cloudflare/boring/pull/41.