### PR TITLE
Pin rust version to 1.54.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install Rust
-        run: rustup update stable && rustup default stable
       - name: Check formatting
         run: cargo fmt --all -- --check
 
@@ -30,8 +28,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: 'recursive'
-      - name: Install Rust
-        run: rustup update stable && rustup default stable
       - name: Get rust version
         id: rust-version
         run: echo "::set-output name=version::$(rustc --version)"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.54.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
In order to avoid breaking CI on master with linters added in new rust versions, we should pin to the current version, and updated when there are features we find desirable. 