### PR TITLE
Update dependencies

### DIFF
--- a/boring/Cargo.toml
+++ b/boring/Cargo.toml
@@ -19,6 +19,5 @@ libc = "0.2"
 boring-sys = { version = "1.1.0", path = "../boring-sys" }
 
 [dev-dependencies]
-tempdir = "0.3"
 hex = "0.4"
 rusty-hook = "^0.11"

--- a/boring/Cargo.toml
+++ b/boring/Cargo.toml
@@ -13,12 +13,12 @@ edition = "2018"
 
 [dependencies]
 bitflags = "1.0"
-foreign-types = "0.3.1"
+foreign-types = "0.5"
 lazy_static = "1"
 libc = "0.2"
 boring-sys = { version = "1.1.0", path = "../boring-sys" }
 
 [dev-dependencies]
 tempdir = "0.3"
-hex = "0.3"
-rusty-hook = "^0.10.1"
+hex = "0.4"
+rusty-hook = "^0.11"

--- a/boring/src/asn1.rs
+++ b/boring/src/asn1.rs
@@ -57,10 +57,6 @@ foreign_type_and_impl_send_sync! {
     ///
     /// [ASN1_GENERALIZEDTIME_set]: https://www.openssl.org/docs/manmaster/man3/ASN1_GENERALIZEDTIME_set.html
     pub struct Asn1GeneralizedTime;
-    /// Reference to a [`Asn1GeneralizedTime`]
-    ///
-    /// [`Asn1GeneralizedTime`]: struct.Asn1GeneralizedTime.html
-    pub struct Asn1GeneralizedTimeRef;
 }
 
 impl fmt::Display for Asn1GeneralizedTimeRef {
@@ -113,10 +109,6 @@ foreign_type_and_impl_send_sync! {
     ///
     /// [ASN_TIME_set]: https://www.openssl.org/docs/man1.1.0/crypto/ASN1_TIME_set.html
     pub struct Asn1Time;
-    /// Reference to an [`Asn1Time`]
-    ///
-    /// [`Asn1Time`]: struct.Asn1Time.html
-    pub struct Asn1TimeRef;
 }
 
 impl Asn1TimeRef {
@@ -327,10 +319,6 @@ foreign_type_and_impl_send_sync! {
     ///
     /// [ASN1_STRING-to_UTF8]: https://www.openssl.org/docs/man1.1.0/crypto/ASN1_STRING_to_UTF8.html
     pub struct Asn1String;
-    /// Reference to [`Asn1String`]
-    ///
-    /// [`Asn1String`]: struct.Asn1String.html
-    pub struct Asn1StringRef;
 }
 
 impl Asn1StringRef {
@@ -395,10 +383,6 @@ foreign_type_and_impl_send_sync! {
     /// [`bn`]: ../bn/index.html
     /// [`ASN1_INTEGER_set`]: https://www.openssl.org/docs/man1.1.0/crypto/ASN1_INTEGER_set.html
     pub struct Asn1Integer;
-    /// Reference to [`Asn1Integer`]
-    ///
-    /// [`Asn1Integer`]: struct.Asn1Integer.html
-    pub struct Asn1IntegerRef;
 }
 
 impl Asn1Integer {
@@ -458,10 +442,6 @@ foreign_type_and_impl_send_sync! {
     ///
     /// [`x509`]: ../x509/struct.X509.html#method.signature
     pub struct Asn1BitString;
-    /// Reference to [`Asn1BitString`]
-    ///
-    /// [`Asn1BitString`]: struct.Asn1BitString.html
-    pub struct Asn1BitStringRef;
 }
 
 impl Asn1BitStringRef {
@@ -499,10 +479,6 @@ foreign_type_and_impl_send_sync! {
     /// [`nid::COMMONNAME`]: ../nid/constant.COMMONNAME.html
     /// [`OBJ_nid2obj`]: https://www.openssl.org/docs/man1.1.0/crypto/OBJ_obj2nid.html
     pub struct Asn1Object;
-    /// Reference to [`Asn1Object`]
-    ///
-    /// [`Asn1Object`]: struct.Asn1Object.html
-    pub struct Asn1ObjectRef;
 }
 
 impl Asn1Object {

--- a/boring/src/bn.rs
+++ b/boring/src/bn.rs
@@ -80,7 +80,7 @@ impl BigNumContext {
     pub fn new() -> Result<BigNumContext, ErrorStack> {
         unsafe {
             ffi::init();
-            cvt_p(ffi::BN_CTX_new()).map(BigNumContext)
+            cvt_p(ffi::BN_CTX_new()).map(|p| BigNumContext::from_ptr(p))
         }
     }
 }

--- a/boring/src/bn.rs
+++ b/boring/src/bn.rs
@@ -65,10 +65,6 @@ foreign_type_and_impl_send_sync! {
     ///
     /// [`BN_CTX`]: https://www.openssl.org/docs/man1.1.0/crypto/BN_CTX_new.html
     pub struct BigNumContext;
-    /// Reference to [`BigNumContext`]
-    ///
-    /// [`BigNumContext`]: struct.BigNumContext.html
-    pub struct BigNumContextRef;
 }
 
 impl BigNumContext {
@@ -113,10 +109,6 @@ foreign_type_and_impl_send_sync! {
     /// # fn main () { bignums(); }
     /// ```
     pub struct BigNum;
-    /// Reference to a [`BigNum`]
-    ///
-    /// [`BigNum`]: struct.BigNum.html
-    pub struct BigNumRef;
 }
 
 impl BigNumRef {

--- a/boring/src/conf.rs
+++ b/boring/src/conf.rs
@@ -29,7 +29,6 @@ foreign_type_and_impl_send_sync! {
     fn drop = ffi::NCONF_free;
 
     pub struct Conf;
-    pub struct ConfRef;
 }
 
 impl Conf {

--- a/boring/src/conf.rs
+++ b/boring/src/conf.rs
@@ -1,5 +1,6 @@
 //! Interface for processing OpenSSL configuration files.
 use crate::ffi;
+use foreign_types::ForeignType;
 use libc::c_void;
 
 use crate::cvt_p;
@@ -34,6 +35,6 @@ foreign_type_and_impl_send_sync! {
 impl Conf {
     /// Create a configuration parser.
     pub fn new(method: ConfMethod) -> Result<Conf, ErrorStack> {
-        unsafe { cvt_p(ffi::NCONF_new(method.as_ptr())).map(Conf) }
+        unsafe { cvt_p(ffi::NCONF_new(method.as_ptr())).map(|p| Conf::from_ptr(p)) }
     }
 }

--- a/boring/src/ec.rs
+++ b/boring/src/ec.rs
@@ -122,7 +122,7 @@ impl EcGroup {
     pub fn from_curve_name(nid: Nid) -> Result<EcGroup, ErrorStack> {
         unsafe {
             init();
-            cvt_p(ffi::EC_GROUP_new_by_curve_name(nid.as_raw())).map(EcGroup)
+            cvt_p(ffi::EC_GROUP_new_by_curve_name(nid.as_raw())).map(|p| EcGroup::from_ptr(p))
         }
     }
 }
@@ -421,7 +421,9 @@ impl EcPointRef {
     ///
     /// [`EC_POINT_dup`]: https://www.openssl.org/docs/man1.1.0/crypto/EC_POINT_dup.html
     pub fn to_owned(&self, group: &EcGroupRef) -> Result<EcPoint, ErrorStack> {
-        unsafe { cvt_p(ffi::EC_POINT_dup(self.as_ptr(), group.as_ptr())).map(EcPoint) }
+        unsafe {
+            cvt_p(ffi::EC_POINT_dup(self.as_ptr(), group.as_ptr())).map(|p| EcPoint::from_ptr(p))
+        }
     }
 
     /// Determines if this point is equal to another.
@@ -479,7 +481,7 @@ impl EcPoint {
     ///
     /// [`EC_POINT_new`]: https://www.openssl.org/docs/man1.1.0/crypto/EC_POINT_new.html
     pub fn new(group: &EcGroupRef) -> Result<EcPoint, ErrorStack> {
-        unsafe { cvt_p(ffi::EC_POINT_new(group.as_ptr())).map(EcPoint) }
+        unsafe { cvt_p(ffi::EC_POINT_new(group.as_ptr())).map(|p| EcPoint::from_ptr(p)) }
     }
 
     /// Creates point from a binary representation

--- a/boring/src/ec.rs
+++ b/boring/src/ec.rs
@@ -107,10 +107,6 @@ foreign_type_and_impl_send_sync! {
     /// [wiki]: https://wiki.openssl.org/index.php/Command_Line_Elliptic_Curve_Operations
     /// [`Nid`]: ../nid/index.html
     pub struct EcGroup;
-    /// Reference to [`EcGroup`]
-    ///
-    /// [`EcGroup`]: struct.EcGroup.html
-    pub struct EcGroupRef;
 }
 
 impl EcGroup {
@@ -259,10 +255,6 @@ foreign_type_and_impl_send_sync! {
     ///
     /// [`EC_POINT_new`]: https://www.openssl.org/docs/man1.1.0/crypto/EC_POINT_new.html
     pub struct EcPoint;
-    /// Reference to [`EcPoint`]
-    ///
-    /// [`EcPoint`]: struct.EcPoint.html
-    pub struct EcPointRef;
 }
 
 impl EcPointRef {

--- a/boring/src/ecdsa.rs
+++ b/boring/src/ecdsa.rs
@@ -22,10 +22,6 @@ foreign_type_and_impl_send_sync! {
     ///
     /// [`ECDSA_sign`]: https://www.openssl.org/docs/man1.1.0/crypto/ECDSA_sign.html
     pub struct EcdsaSig;
-    /// Reference to [`EcdsaSig`]
-    ///
-    /// [`EcdsaSig`]: struct.EcdsaSig.html
-    pub struct EcdsaSigRef;
 }
 
 impl EcdsaSig {

--- a/boring/src/lib.rs
+++ b/boring/src/lib.rs
@@ -13,8 +13,6 @@ extern crate libc;
 
 #[cfg(test)]
 extern crate hex;
-#[cfg(test)]
-extern crate tempdir;
 
 #[doc(inline)]
 pub use crate::ffi::init;

--- a/boring/src/macros.rs
+++ b/boring/src/macros.rs
@@ -145,19 +145,13 @@ macro_rules! foreign_type_and_impl_send_sync {
         => {
             foreign_type! {
                 $(#[$impl_attr])*
-                type CType = $ctype;
-                fn drop = $drop;
-                $(fn clone = $clone;)*
                 $(#[$owned_attr])*
-                pub struct $owned;
-                $(#[$borrowed_attr])*
-                pub struct $borrowed;
+                pub unsafe type $owned: Send + Sync {
+                    type CType = $ctype;
+                    fn drop = $drop;
+                    $(fn clone = $clone;)*
+                }
             }
-
-            unsafe impl Send for $owned{}
-            unsafe impl Send for $borrowed{}
-            unsafe impl Sync for $owned{}
-            unsafe impl Sync for $borrowed{}
         };
 }
 
@@ -177,7 +171,7 @@ macro_rules! generic_foreign_type_and_impl_send_sync {
         pub struct $owned<T>(*mut $ctype, ::std::marker::PhantomData<T>);
 
         $(#[$impl_attr])*
-        impl<T> ::foreign_types::ForeignType for $owned<T> {
+        unsafe impl<T> ::foreign_types::ForeignType for $owned<T> {
             type CType = $ctype;
             type Ref = $borrowed<T>;
 
@@ -257,7 +251,7 @@ macro_rules! generic_foreign_type_and_impl_send_sync {
         pub struct $borrowed<T>(::foreign_types::Opaque, ::std::marker::PhantomData<T>);
 
         $(#[$impl_attr])*
-        impl<T> ::foreign_types::ForeignTypeRef for $borrowed<T> {
+        unsafe impl<T> ::foreign_types::ForeignTypeRef for $borrowed<T> {
             type CType = $ctype;
         }
 

--- a/boring/src/macros.rs
+++ b/boring/src/macros.rs
@@ -139,8 +139,6 @@ macro_rules! foreign_type_and_impl_send_sync {
 
         $(#[$owned_attr:meta])*
         pub struct $owned:ident;
-        $(#[$borrowed_attr:meta])*
-        pub struct $borrowed:ident;
     )
         => {
             foreign_type! {

--- a/boring/src/pkcs12.rs
+++ b/boring/src/pkcs12.rs
@@ -196,7 +196,7 @@ impl Pkcs12Builder {
                 self.mac_iter,
                 keytype,
             ))
-            .map(Pkcs12)
+            .map(|p| Pkcs12::from_ptr(p))
         }
     }
 }

--- a/boring/src/pkcs12.rs
+++ b/boring/src/pkcs12.rs
@@ -20,7 +20,6 @@ foreign_type_and_impl_send_sync! {
     fn drop = ffi::PKCS12_free;
 
     pub struct Pkcs12;
-    pub struct Pkcs12Ref;
 }
 
 impl Pkcs12Ref {

--- a/boring/src/srtp.rs
+++ b/boring/src/srtp.rs
@@ -13,8 +13,6 @@ foreign_type_and_impl_send_sync! {
     fn drop = free;
 
     pub struct SrtpProtectionProfile;
-    /// Reference to `SrtpProtectionProfile`.
-    pub struct SrtpProtectionProfileRef;
 }
 
 impl Stackable for SrtpProtectionProfile {

--- a/boring/src/ssl/mod.rs
+++ b/boring/src/ssl/mod.rs
@@ -1585,11 +1585,6 @@ foreign_type_and_impl_send_sync! {
     /// Applications commonly configure a single `SslContext` that is shared by all of its
     /// `SslStreams`.
     pub struct SslContext;
-
-    /// Reference to [`SslContext`]
-    ///
-    /// [`SslContext`]: struct.SslContext.html
-    pub struct SslContextRef;
 }
 
 impl Clone for SslContext {
@@ -1964,11 +1959,6 @@ foreign_type_and_impl_send_sync! {
     ///
     /// These can be cached to share sessions across connections.
     pub struct SslSession;
-
-    /// Reference to [`SslSession`].
-    ///
-    /// [`SslSession`]: struct.SslSession.html
-    pub struct SslSessionRef;
 }
 
 impl Clone for SslSession {
@@ -2092,11 +2082,6 @@ foreign_type_and_impl_send_sync! {
     ///
     /// [`SslContext`]: struct.SslContext.html
     pub struct Ssl;
-
-    /// Reference to an [`Ssl`].
-    ///
-    /// [`Ssl`]: struct.Ssl.html
-    pub struct SslRef;
 }
 
 impl fmt::Debug for Ssl {

--- a/boring/src/ssl/mod.rs
+++ b/boring/src/ssl/mod.rs
@@ -73,7 +73,7 @@ use std::mem::{self, ManuallyDrop};
 use std::ops::{Deref, DerefMut};
 use std::panic::resume_unwind;
 use std::path::Path;
-use std::ptr;
+use std::ptr::{self, NonNull};
 use std::slice;
 use std::str;
 use std::sync::{Arc, Mutex};
@@ -1829,7 +1829,7 @@ impl ClientHello {
 /// Information about a cipher.
 pub struct SslCipher(*mut ffi::SSL_CIPHER);
 
-impl ForeignType for SslCipher {
+unsafe impl ForeignType for SslCipher {
     type CType = ffi::SSL_CIPHER;
     type Ref = SslCipherRef;
 
@@ -1863,7 +1863,7 @@ impl DerefMut for SslCipher {
 /// [`SslCipher`]: struct.SslCipher.html
 pub struct SslCipherRef(Opaque);
 
-impl ForeignTypeRef for SslCipherRef {
+unsafe impl ForeignTypeRef for SslCipherRef {
     type CType = ffi::SSL_CIPHER;
 }
 
@@ -1997,7 +1997,7 @@ impl ToOwned for SslSessionRef {
     fn to_owned(&self) -> SslSession {
         unsafe {
             SSL_SESSION_up_ref(self.as_ptr());
-            SslSession(self.as_ptr())
+            SslSession(NonNull::new_unchecked(self.as_ptr()))
         }
     }
 }

--- a/boring/src/ssl/test/mod.rs
+++ b/boring/src/ssl/test/mod.rs
@@ -14,7 +14,6 @@ use std::process::{Child, ChildStdin, Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 use std::time::Duration;
-use tempdir::TempDir;
 
 use crate::dh::Dh;
 use crate::error::ErrorStack;

--- a/boring/src/stack.rs
+++ b/boring/src/stack.rs
@@ -89,7 +89,7 @@ impl<T: Stackable> Borrow<StackRef<T>> for Stack<T> {
     }
 }
 
-impl<T: Stackable> ForeignType for Stack<T> {
+unsafe impl<T: Stackable> ForeignType for Stack<T> {
     type CType = T::StackType;
     type Ref = StackRef<T>;
 
@@ -170,7 +170,7 @@ pub struct StackRef<T: Stackable>(Opaque, PhantomData<T>);
 unsafe impl<T: Stackable + Send> Send for StackRef<T> {}
 unsafe impl<T: Stackable + Sync> Sync for StackRef<T> {}
 
-impl<T: Stackable> ForeignTypeRef for StackRef<T> {
+unsafe impl<T: Stackable> ForeignTypeRef for StackRef<T> {
     type CType = T::StackType;
 }
 

--- a/boring/src/string.rs
+++ b/boring/src/string.rs
@@ -14,7 +14,6 @@ foreign_type_and_impl_send_sync! {
     fn drop = free;
 
     pub struct OpensslString;
-    pub struct OpensslStringRef;
 }
 
 impl fmt::Display for OpensslString {

--- a/boring/src/x509/mod.rs
+++ b/boring/src/x509/mod.rs
@@ -47,9 +47,6 @@ foreign_type_and_impl_send_sync! {
 
     /// An `X509` certificate store context.
     pub struct X509StoreContext;
-
-    /// Reference to `X509StoreContext`.
-    pub struct X509StoreContextRef;
 }
 
 impl X509StoreContext {
@@ -379,8 +376,6 @@ foreign_type_and_impl_send_sync! {
 
     /// An `X509` public key certificate.
     pub struct X509;
-    /// Reference to `X509`.
-    pub struct X509Ref;
 }
 
 impl X509Ref {
@@ -733,8 +728,6 @@ foreign_type_and_impl_send_sync! {
 
     /// Permit additional fields to be added to an `X509` v3 certificate.
     pub struct X509Extension;
-    /// Reference to `X509Extension`.
-    pub struct X509ExtensionRef;
 }
 
 impl Stackable for X509Extension {
@@ -863,8 +856,6 @@ foreign_type_and_impl_send_sync! {
 
     /// The names of an `X509` certificate.
     pub struct X509Name;
-    /// Reference to `X509Name`.
-    pub struct X509NameRef;
 }
 
 impl X509Name {
@@ -956,8 +947,6 @@ foreign_type_and_impl_send_sync! {
 
     /// A name entry associated with a `X509Name`.
     pub struct X509NameEntry;
-    /// Reference to `X509NameEntry`.
-    pub struct X509NameEntryRef;
 }
 
 impl X509NameEntryRef {
@@ -1114,8 +1103,6 @@ foreign_type_and_impl_send_sync! {
 
     /// An `X509` certificate request.
     pub struct X509Req;
-    /// Reference to `X509Req`.
-    pub struct X509ReqRef;
 }
 
 impl X509Req {
@@ -1298,8 +1285,6 @@ foreign_type_and_impl_send_sync! {
 
     /// An `X509` certificate alternative names.
     pub struct GeneralName;
-    /// Reference to `GeneralName`.
-    pub struct GeneralNameRef;
 }
 
 impl GeneralNameRef {
@@ -1377,8 +1362,6 @@ foreign_type_and_impl_send_sync! {
 
     /// An `X509` certificate signature algorithm.
     pub struct X509Algorithm;
-    /// Reference to `X509Algorithm`.
-    pub struct X509AlgorithmRef;
 }
 
 impl X509AlgorithmRef {
@@ -1399,8 +1382,6 @@ foreign_type_and_impl_send_sync! {
 
     /// An `X509` or an X509 certificate revocation list.
     pub struct X509Object;
-    /// Reference to `X509Object`
-    pub struct X509ObjectRef;
 }
 
 impl X509ObjectRef {

--- a/boring/src/x509/mod.rs
+++ b/boring/src/x509/mod.rs
@@ -67,7 +67,7 @@ impl X509StoreContext {
     pub fn new() -> Result<X509StoreContext, ErrorStack> {
         unsafe {
             ffi::init();
-            cvt_p(ffi::X509_STORE_CTX_new()).map(X509StoreContext)
+            cvt_p(ffi::X509_STORE_CTX_new()).map(|p| X509StoreContext::from_ptr(p))
         }
     }
 }
@@ -226,7 +226,7 @@ impl X509Builder {
     pub fn new() -> Result<X509Builder, ErrorStack> {
         unsafe {
             ffi::init();
-            cvt_p(ffi::X509_new()).map(|p| X509Builder(X509(p)))
+            cvt_p(ffi::X509_new()).map(|p| X509Builder(X509::from_ptr(p)))
         }
     }
 
@@ -664,7 +664,7 @@ impl X509 {
 
                     return Err(ErrorStack::get());
                 } else {
-                    certs.push(X509(r));
+                    certs.push(X509::from_ptr(r));
                 }
             }
 
@@ -764,7 +764,8 @@ impl X509Extension {
             let name = name.as_ptr() as *mut _;
             let value = value.as_ptr() as *mut _;
 
-            cvt_p(ffi::X509V3_EXT_nconf(conf, context, name, value)).map(X509Extension)
+            cvt_p(ffi::X509V3_EXT_nconf(conf, context, name, value))
+                .map(|p| X509Extension::from_ptr(p))
         }
     }
 
@@ -789,7 +790,8 @@ impl X509Extension {
             let name = name.as_raw();
             let value = value.as_ptr() as *mut _;
 
-            cvt_p(ffi::X509V3_EXT_nconf_nid(conf, context, name, value)).map(X509Extension)
+            cvt_p(ffi::X509V3_EXT_nconf_nid(conf, context, name, value))
+                .map(|p| X509Extension::from_ptr(p))
         }
     }
 }
@@ -802,7 +804,7 @@ impl X509NameBuilder {
     pub fn new() -> Result<X509NameBuilder, ErrorStack> {
         unsafe {
             ffi::init();
-            cvt_p(ffi::X509_NAME_new()).map(|p| X509NameBuilder(X509Name(p)))
+            cvt_p(ffi::X509_NAME_new()).map(|p| X509NameBuilder(X509Name::from_ptr(p)))
         }
     }
 
@@ -1003,7 +1005,7 @@ impl X509ReqBuilder {
     pub fn new() -> Result<X509ReqBuilder, ErrorStack> {
         unsafe {
             ffi::init();
-            cvt_p(ffi::X509_REQ_new()).map(|p| X509ReqBuilder(X509Req(p)))
+            cvt_p(ffi::X509_REQ_new()).map(|p| X509ReqBuilder(X509Req::from_ptr(p)))
         }
     }
 

--- a/boring/src/x509/store.rs
+++ b/boring/src/x509/store.rs
@@ -49,8 +49,6 @@ foreign_type_and_impl_send_sync! {
 
     /// A builder type used to construct an `X509Store`.
     pub struct X509StoreBuilder;
-    /// Reference to an `X509StoreBuilder`.
-    pub struct X509StoreBuilderRef;
 }
 
 impl X509StoreBuilder {
@@ -96,8 +94,6 @@ foreign_type_and_impl_send_sync! {
 
     /// A certificate store to hold trusted `X509` certificates.
     pub struct X509Store;
-    /// Reference to an `X509Store`.
-    pub struct X509StoreRef;
 }
 
 impl X509StoreRef {

--- a/boring/src/x509/store.rs
+++ b/boring/src/x509/store.rs
@@ -35,7 +35,7 @@
 //! ```
 
 use crate::ffi;
-use foreign_types::ForeignTypeRef;
+use foreign_types::{ForeignType, ForeignTypeRef};
 use std::mem;
 
 use crate::error::ErrorStack;
@@ -61,7 +61,7 @@ impl X509StoreBuilder {
         unsafe {
             ffi::init();
 
-            cvt_p(ffi::X509_STORE_new()).map(X509StoreBuilder)
+            cvt_p(ffi::X509_STORE_new()).map(|p| X509StoreBuilder::from_ptr(p))
         }
     }
 

--- a/boring/src/x509/verify.rs
+++ b/boring/src/x509/verify.rs
@@ -27,8 +27,6 @@ foreign_type_and_impl_send_sync! {
 
     /// Adjust parameters associated with certificate verification.
     pub struct X509VerifyParam;
-    /// Reference to `X509VerifyParam`.
-    pub struct X509VerifyParamRef;
 }
 
 impl X509VerifyParamRef {


### PR DESCRIPTION
In particular, this updates `foreign-types`, which had a lot of breaking changes.

- `ForeignType` is now an unsafe trait. We should be fine since we don't change the pointer  when calling to_ptr or from_ptr: https://github.com/sfackler/foreign-types/commit/3bd4f4fb7eebab09a608ebbd0bbe48b51a20b8a5#r54645666
- `*Ref` types no longer need a separate macro call, they're generated automatically
- Generated types now store `NonNull<T>` instead of `*mut T`