### PR TITLE
Replace OUT_DIR variable with BINDGEN_SRC for include! macro

### DIFF
--- a/boring-sys/build.rs
+++ b/boring-sys/build.rs
@@ -272,8 +272,11 @@ fn main() {
     }
 
     let bindings = builder.generate().expect("Unable to generate bindings");
-    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let out_path = PathBuf::from(&out_dir);
     bindings
         .write_to_file(out_path.join("bindings.rs"))
         .expect("Couldn't write bindings!");
+
+    println!("cargo:rustc-env=BINDGEN_SRC={}/bindings.rs", out_dir);
 }

--- a/boring-sys/src/lib.rs
+++ b/boring-sys/src/lib.rs
@@ -17,7 +17,7 @@ use std::os::raw::{c_char, c_int, c_uint, c_ulong};
 
 #[allow(deref_nullptr)] // TODO: remove this when https://github.com/rust-lang/rust-bindgen/issues/1651 finally gets fixed
 mod generated {
-    include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+    include!(env!("BINDGEN_SRC"));
 }
 pub use generated::*;
 


### PR DESCRIPTION
This small fix can help build this crate with bazel and rules_rust so easily.
Bazel can locate single file with $(locate) but cannot pass a directory of a single file with an absolute path.
