### PR TITLE
Update `boring` to 2018 edition

### DIFF
--- a/boring/Cargo.toml
+++ b/boring/Cargo.toml
@@ -9,6 +9,7 @@ documentation = "https://docs.rs/boring"
 readme = "README.md"
 keywords = ["crypto", "tls", "ssl", "dtls"]
 categories = ["cryptography", "api-bindings"]
+edition = "2018"
 
 [dependencies]
 bitflags = "1.0"

--- a/boring/src/aes.rs
+++ b/boring/src/aes.rs
@@ -37,7 +37,7 @@
 //! assert_eq!(&orig_key[..], &key_to_wrap[..]);
 //! ```
 //!
-use ffi;
+use crate::ffi;
 use libc::{c_int, c_uint, size_t};
 use std::{mem, ptr};
 

--- a/boring/src/asn1.rs
+++ b/boring/src/asn1.rs
@@ -24,7 +24,7 @@
 //! use boring::asn1::Asn1Time;
 //! let tomorrow = Asn1Time::days_from_now(1);
 //! ```
-use ffi;
+use crate::ffi;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use libc::{c_char, c_int, c_long, time_t};
 use std::cmp::Ordering;
@@ -34,12 +34,12 @@ use std::ptr;
 use std::slice;
 use std::str;
 
-use bio::MemBio;
-use bn::{BigNum, BigNumRef};
-use error::ErrorStack;
-use nid::Nid;
-use string::OpensslString;
-use {cvt, cvt_p};
+use crate::bio::MemBio;
+use crate::bn::{BigNum, BigNumRef};
+use crate::error::ErrorStack;
+use crate::nid::Nid;
+use crate::string::OpensslString;
+use crate::{cvt, cvt_p};
 
 foreign_type_and_impl_send_sync! {
     type CType = ffi::ASN1_GENERALIZEDTIME;
@@ -418,7 +418,7 @@ impl Asn1IntegerRef {
     #[allow(missing_docs)]
     #[deprecated(since = "0.10.6", note = "use to_bn instead")]
     pub fn get(&self) -> i64 {
-        unsafe { ::ffi::ASN1_INTEGER_get(self.as_ptr()) as i64 }
+        unsafe { crate::ffi::ASN1_INTEGER_get(self.as_ptr()) as i64 }
     }
 
     /// Converts the integer to a `BigNum`.
@@ -428,8 +428,11 @@ impl Asn1IntegerRef {
     /// [`ASN1_INTEGER_to_BN`]: https://www.openssl.org/docs/man1.1.0/crypto/ASN1_INTEGER_get.html
     pub fn to_bn(&self) -> Result<BigNum, ErrorStack> {
         unsafe {
-            cvt_p(::ffi::ASN1_INTEGER_to_BN(self.as_ptr(), ptr::null_mut()))
-                .map(|p| BigNum::from_ptr(p))
+            cvt_p(crate::ffi::ASN1_INTEGER_to_BN(
+                self.as_ptr(),
+                ptr::null_mut(),
+            ))
+            .map(|p| BigNum::from_ptr(p))
         }
     }
 
@@ -441,7 +444,7 @@ impl Asn1IntegerRef {
     /// [`bn`]: ../bn/struct.BigNumRef.html#method.to_asn1_integer
     /// [`ASN1_INTEGER_set`]: https://www.openssl.org/docs/man1.1.0/crypto/ASN1_INTEGER_set.html
     pub fn set(&mut self, value: i32) -> Result<(), ErrorStack> {
-        unsafe { cvt(::ffi::ASN1_INTEGER_set(self.as_ptr(), value as c_long)).map(|_| ()) }
+        unsafe { cvt(crate::ffi::ASN1_INTEGER_set(self.as_ptr(), value as c_long)).map(|_| ()) }
     }
 }
 
@@ -551,14 +554,14 @@ impl fmt::Debug for Asn1ObjectRef {
     }
 }
 
-use ffi::ASN1_STRING_get0_data;
+use crate::ffi::ASN1_STRING_get0_data;
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    use bn::BigNum;
-    use nid::Nid;
+    use crate::bn::BigNum;
+    use crate::nid::Nid;
 
     /// Tests conversion between BigNum and Asn1Integer.
     #[test]

--- a/boring/src/base64.rs
+++ b/boring/src/base64.rs
@@ -1,7 +1,7 @@
 //! Base64 encoding support.
-use cvt_n;
-use error::ErrorStack;
-use ffi;
+use crate::cvt_n;
+use crate::error::ErrorStack;
+use crate::ffi;
 use libc::c_int;
 
 /// Encodes a slice of bytes to a base64 string.

--- a/boring/src/bio.rs
+++ b/boring/src/bio.rs
@@ -1,12 +1,12 @@
-use ffi;
-use ffi::BIO_new_mem_buf;
+use crate::ffi;
+use crate::ffi::BIO_new_mem_buf;
 use libc::c_int;
 use std::marker::PhantomData;
 use std::ptr;
 use std::slice;
 
-use cvt_p;
-use error::ErrorStack;
+use crate::cvt_p;
+use crate::error::ErrorStack;
 
 pub struct MemBioSlice<'a>(*mut ffi::BIO, PhantomData<&'a [u8]>);
 

--- a/boring/src/bn.rs
+++ b/boring/src/bn.rs
@@ -22,7 +22,7 @@
 //! ```
 //!
 //! [`BIGNUM`]: https://wiki.openssl.org/index.php/Manual:Bn_internal(3)
-use ffi;
+use crate::ffi;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use libc::{c_int, size_t};
 use std::cmp::Ordering;
@@ -30,11 +30,11 @@ use std::ffi::CString;
 use std::ops::{Add, Deref, Div, Mul, Neg, Rem, Shl, Shr, Sub};
 use std::{fmt, ptr};
 
-use asn1::Asn1Integer;
-use error::ErrorStack;
-use ffi::BN_is_negative;
-use string::OpensslString;
-use {cvt, cvt_n, cvt_p};
+use crate::asn1::Asn1Integer;
+use crate::error::ErrorStack;
+use crate::ffi::BN_is_negative;
+use crate::string::OpensslString;
+use crate::{cvt, cvt_n, cvt_p};
 
 /// Options for the most significant bits of a randomly generated `BigNum`.
 pub struct MsbOption(c_int);
@@ -1231,7 +1231,7 @@ impl Neg for BigNum {
 
 #[cfg(test)]
 mod tests {
-    use bn::{BigNum, BigNumContext};
+    use crate::bn::{BigNum, BigNumContext};
 
     #[test]
     fn test_to_from_slice() {

--- a/boring/src/conf.rs
+++ b/boring/src/conf.rs
@@ -1,9 +1,9 @@
 //! Interface for processing OpenSSL configuration files.
-use ffi;
+use crate::ffi;
 use libc::c_void;
 
-use cvt_p;
-use error::ErrorStack;
+use crate::cvt_p;
+use crate::error::ErrorStack;
 
 pub struct ConfMethod(*mut c_void);
 

--- a/boring/src/derive.rs
+++ b/boring/src/derive.rs
@@ -1,12 +1,12 @@
 //! Shared secret derivation.
-use ffi;
+use crate::ffi;
 use foreign_types::ForeignTypeRef;
 use std::marker::PhantomData;
 use std::ptr;
 
-use error::ErrorStack;
-use pkey::{HasPrivate, HasPublic, PKeyRef};
-use {cvt, cvt_p};
+use crate::error::ErrorStack;
+use crate::pkey::{HasPrivate, HasPublic, PKeyRef};
+use crate::{cvt, cvt_p};
 
 /// A type used to derive a shared secret between two keys.
 pub struct Deriver<'a>(*mut ffi::EVP_PKEY_CTX, PhantomData<&'a ()>);
@@ -97,9 +97,9 @@ impl<'a> Deriver<'a> {
 mod test {
     use super::*;
 
-    use ec::{EcGroup, EcKey};
-    use nid::Nid;
-    use pkey::PKey;
+    use crate::ec::{EcGroup, EcKey};
+    use crate::nid::Nid;
+    use crate::pkey::PKey;
 
     #[test]
     fn derive_without_peer() {

--- a/boring/src/dh.rs
+++ b/boring/src/dh.rs
@@ -1,12 +1,12 @@
-use error::ErrorStack;
-use ffi;
+use crate::error::ErrorStack;
+use crate::ffi;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use std::mem;
 use std::ptr;
 
-use bn::BigNum;
-use pkey::{HasParams, Params};
-use {cvt, cvt_p};
+use crate::bn::BigNum;
+use crate::pkey::{HasParams, Params};
+use crate::{cvt, cvt_p};
 
 generic_foreign_type_and_impl_send_sync! {
     type CType = ffi::DH;
@@ -80,13 +80,13 @@ impl Dh<Params> {
     }
 }
 
-use ffi::DH_set0_pqg;
+use crate::ffi::DH_set0_pqg;
 
 #[cfg(test)]
 mod tests {
-    use bn::BigNum;
-    use dh::Dh;
-    use ssl::{SslContext, SslMethod};
+    use crate::bn::BigNum;
+    use crate::dh::Dh;
+    use crate::ssl::{SslContext, SslMethod};
 
     #[test]
     fn test_dh() {

--- a/boring/src/dsa.rs
+++ b/boring/src/dsa.rs
@@ -5,17 +5,17 @@
 //! using the private key that can be validated with the public key but not be generated
 //! without the private key.
 
-use ffi;
+use crate::ffi;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use libc::c_uint;
 use std::fmt;
 use std::mem;
 use std::ptr;
 
-use bn::{BigNum, BigNumRef};
-use error::ErrorStack;
-use pkey::{HasParams, HasPrivate, HasPublic, Private, Public};
-use {cvt, cvt_p};
+use crate::bn::{BigNum, BigNumRef};
+use crate::error::ErrorStack;
+use crate::pkey::{HasParams, HasPrivate, HasPublic, Private, Public};
+use crate::{cvt, cvt_p};
 
 generic_foreign_type_and_impl_send_sync! {
     type CType = ffi::DSA;
@@ -293,12 +293,12 @@ impl<T> fmt::Debug for Dsa<T> {
     }
 }
 
-use ffi::{DSA_get0_key, DSA_get0_pqg, DSA_set0_key, DSA_set0_pqg};
+use crate::ffi::{DSA_get0_key, DSA_get0_pqg, DSA_set0_key, DSA_set0_pqg};
 
 #[cfg(test)]
 mod test {
     use super::*;
-    use bn::BigNumContext;
+    use crate::bn::BigNumContext;
 
     #[test]
     pub fn test_generate() {

--- a/boring/src/ec.rs
+++ b/boring/src/ec.rs
@@ -15,17 +15,17 @@
 //! [`EcGroup`]: struct.EcGroup.html
 //! [`Nid`]: ../nid/struct.Nid.html
 //! [Eliptic Curve Cryptography]: https://wiki.openssl.org/index.php/Elliptic_Curve_Cryptography
-use ffi;
+use crate::ffi;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use libc::c_int;
 use std::fmt;
 use std::ptr;
 
-use bn::{BigNumContextRef, BigNumRef};
-use error::ErrorStack;
-use nid::Nid;
-use pkey::{HasParams, HasPrivate, HasPublic, Params, Private, Public};
-use {cvt, cvt_n, cvt_p, init};
+use crate::bn::{BigNumContextRef, BigNumRef};
+use crate::error::ErrorStack;
+use crate::nid::Nid;
+use crate::pkey::{HasParams, HasPrivate, HasPublic, Params, Private, Public};
+use crate::{cvt, cvt_n, cvt_p, init};
 
 /// Compressed or Uncompressed conversion
 ///
@@ -869,8 +869,8 @@ mod test {
     use hex::FromHex;
 
     use super::*;
-    use bn::{BigNum, BigNumContext};
-    use nid::Nid;
+    use crate::bn::{BigNum, BigNumContext};
+    use crate::nid::Nid;
 
     #[test]
     fn key_new_by_curve_name() {

--- a/boring/src/ecdsa.rs
+++ b/boring/src/ecdsa.rs
@@ -1,16 +1,16 @@
 //! Low level Elliptic Curve Digital Signature Algorithm (ECDSA) functions.
 
-use ffi;
+use crate::ffi;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use libc::{c_int, size_t};
 use std::mem;
 use std::ptr;
 
-use bn::{BigNum, BigNumRef};
-use ec::EcKeyRef;
-use error::ErrorStack;
-use pkey::{HasPrivate, HasPublic};
-use {cvt_n, cvt_p};
+use crate::bn::{BigNum, BigNumRef};
+use crate::ec::EcKeyRef;
+use crate::error::ErrorStack;
+use crate::pkey::{HasPrivate, HasPublic};
+use crate::{cvt_n, cvt_p};
 
 foreign_type_and_impl_send_sync! {
     type CType = ffi::ECDSA_SIG;
@@ -136,4 +136,4 @@ impl EcdsaSigRef {
     }
 }
 
-use ffi::{ECDSA_SIG_get0, ECDSA_SIG_set0};
+use crate::ffi::{ECDSA_SIG_get0, ECDSA_SIG_set0};

--- a/boring/src/error.rs
+++ b/boring/src/error.rs
@@ -24,7 +24,7 @@ use std::io;
 use std::ptr;
 use std::str;
 
-use ffi;
+use crate::ffi;
 
 /// Collection of [`Error`]s from OpenSSL.
 ///

--- a/boring/src/fips.rs
+++ b/boring/src/fips.rs
@@ -3,9 +3,9 @@
 //! See [OpenSSL's documentation] for details.
 //!
 //! [OpenSSL's documentation]: https://www.openssl.org/docs/fips/UserGuide-2.0.pdf
-use cvt;
-use error::ErrorStack;
-use ffi;
+use crate::cvt;
+use crate::error::ErrorStack;
+use crate::ffi;
 
 /// Moves the library into or out of the FIPS 140-2 mode of operation.
 ///

--- a/boring/src/hash.rs
+++ b/boring/src/hash.rs
@@ -1,4 +1,4 @@
-use ffi;
+use crate::ffi;
 use std::convert::TryInto;
 use std::fmt;
 use std::io;
@@ -6,10 +6,10 @@ use std::io::prelude::*;
 use std::ops::{Deref, DerefMut};
 use std::ptr;
 
-use error::ErrorStack;
-use ffi::{EVP_MD_CTX_free, EVP_MD_CTX_new};
-use nid::Nid;
-use {cvt, cvt_p};
+use crate::error::ErrorStack;
+use crate::ffi::{EVP_MD_CTX_free, EVP_MD_CTX_new};
+use crate::nid::Nid;
+use crate::{cvt, cvt_p};
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub struct MessageDigest(*const ffi::EVP_MD);

--- a/boring/src/lib.rs
+++ b/boring/src/lib.rs
@@ -17,11 +17,11 @@ extern crate hex;
 extern crate tempdir;
 
 #[doc(inline)]
-pub use ffi::init;
+pub use crate::ffi::init;
 
 use libc::{c_int, size_t};
 
-use error::ErrorStack;
+use crate::error::ErrorStack;
 
 #[macro_use]
 mod macros;

--- a/boring/src/macros.rs
+++ b/boring/src/macros.rs
@@ -3,10 +3,10 @@ macro_rules! private_key_from_pem {
         from_pem!($(#[$m])* $n, $t, $f);
 
         $(#[$m2])*
-        pub fn $n2(pem: &[u8], passphrase: &[u8]) -> Result<$t, ::error::ErrorStack> {
+        pub fn $n2(pem: &[u8], passphrase: &[u8]) -> Result<$t, crate::error::ErrorStack> {
             unsafe {
                 ffi::init();
-                let bio = ::bio::MemBioSlice::new(pem)?;
+                let bio = crate::bio::MemBioSlice::new(pem)?;
                 let passphrase = ::std::ffi::CString::new(passphrase).unwrap();
                 cvt_p($f(bio.as_ptr(),
                          ptr::null_mut(),
@@ -17,16 +17,16 @@ macro_rules! private_key_from_pem {
         }
 
         $(#[$m3])*
-        pub fn $n3<F>(pem: &[u8], callback: F) -> Result<$t, ::error::ErrorStack>
-            where F: FnOnce(&mut [u8]) -> Result<usize, ::error::ErrorStack>
+        pub fn $n3<F>(pem: &[u8], callback: F) -> Result<$t, crate::error::ErrorStack>
+            where F: FnOnce(&mut [u8]) -> Result<usize, crate::error::ErrorStack>
         {
             unsafe {
                 ffi::init();
-                let mut cb = ::util::CallbackState::new(callback);
-                let bio = ::bio::MemBioSlice::new(pem)?;
+                let mut cb = crate::util::CallbackState::new(callback);
+                let bio = crate::bio::MemBioSlice::new(pem)?;
                 cvt_p($f(bio.as_ptr(),
                          ptr::null_mut(),
-                         Some(::util::invoke_passwd_cb::<F>),
+                         Some(crate::util::invoke_passwd_cb::<F>),
                          &mut cb as *mut _ as *mut _))
                     .map(|p| ::foreign_types::ForeignType::from_ptr(p))
             }
@@ -37,9 +37,9 @@ macro_rules! private_key_from_pem {
 macro_rules! private_key_to_pem {
     ($(#[$m:meta])* $n:ident, $(#[$m2:meta])* $n2:ident, $f:path) => {
         $(#[$m])*
-        pub fn $n(&self) -> Result<Vec<u8>, ::error::ErrorStack> {
+        pub fn $n(&self) -> Result<Vec<u8>, crate::error::ErrorStack> {
             unsafe {
-                let bio = ::bio::MemBio::new()?;
+                let bio = crate::bio::MemBio::new()?;
                 cvt($f(bio.as_ptr(),
                         self.as_ptr(),
                         ptr::null(),
@@ -54,11 +54,11 @@ macro_rules! private_key_to_pem {
         $(#[$m2])*
         pub fn $n2(
             &self,
-            cipher: ::symm::Cipher,
+            cipher: crate::symm::Cipher,
             passphrase: &[u8]
-        ) -> Result<Vec<u8>, ::error::ErrorStack> {
+        ) -> Result<Vec<u8>, crate::error::ErrorStack> {
             unsafe {
-                let bio = ::bio::MemBio::new()?;
+                let bio = crate::bio::MemBio::new()?;
                 assert!(passphrase.len() <= ::libc::c_int::max_value() as usize);
                 cvt($f(bio.as_ptr(),
                         self.as_ptr(),
@@ -76,9 +76,9 @@ macro_rules! private_key_to_pem {
 macro_rules! to_pem {
     ($(#[$m:meta])* $n:ident, $f:path) => {
         $(#[$m])*
-        pub fn $n(&self) -> Result<Vec<u8>, ::error::ErrorStack> {
+        pub fn $n(&self) -> Result<Vec<u8>, crate::error::ErrorStack> {
             unsafe {
-                let bio = ::bio::MemBio::new()?;
+                let bio = crate::bio::MemBio::new()?;
                 cvt($f(bio.as_ptr(), self.as_ptr()))?;
                 Ok(bio.get_buf().to_owned())
             }
@@ -89,12 +89,12 @@ macro_rules! to_pem {
 macro_rules! to_der {
     ($(#[$m:meta])* $n:ident, $f:path) => {
         $(#[$m])*
-        pub fn $n(&self) -> Result<Vec<u8>, ::error::ErrorStack> {
+        pub fn $n(&self) -> Result<Vec<u8>, crate::error::ErrorStack> {
             unsafe {
-                let len = ::cvt($f(::foreign_types::ForeignTypeRef::as_ptr(self),
+                let len = crate::cvt($f(::foreign_types::ForeignTypeRef::as_ptr(self),
                                         ptr::null_mut()))?;
                 let mut buf = vec![0; len as usize];
-                ::cvt($f(::foreign_types::ForeignTypeRef::as_ptr(self),
+                crate::cvt($f(::foreign_types::ForeignTypeRef::as_ptr(self),
                               &mut buf.as_mut_ptr()))?;
                 Ok(buf)
             }
@@ -105,11 +105,11 @@ macro_rules! to_der {
 macro_rules! from_der {
     ($(#[$m:meta])* $n:ident, $t:ty, $f:path, $len_ty:ty) => {
         $(#[$m])*
-        pub fn $n(der: &[u8]) -> Result<$t, ::error::ErrorStack> {
+        pub fn $n(der: &[u8]) -> Result<$t, crate::error::ErrorStack> {
             unsafe {
-                ::ffi::init();
+                crate::ffi::init();
                 let len = ::std::cmp::min(der.len(), <$len_ty>::max_value() as usize) as $len_ty;
-                ::cvt_p($f(::std::ptr::null_mut(), &mut der.as_ptr(), len))
+                crate::cvt_p($f(::std::ptr::null_mut(), &mut der.as_ptr(), len))
                     .map(|p| ::foreign_types::ForeignType::from_ptr(p))
             }
         }
@@ -119,10 +119,10 @@ macro_rules! from_der {
 macro_rules! from_pem {
     ($(#[$m:meta])* $n:ident, $t:ty, $f:path) => {
         $(#[$m])*
-        pub fn $n(pem: &[u8]) -> Result<$t, ::error::ErrorStack> {
+        pub fn $n(pem: &[u8]) -> Result<$t, crate::error::ErrorStack> {
             unsafe {
-                ::init();
-                let bio = ::bio::MemBioSlice::new(pem)?;
+                crate::init();
+                let bio = crate::bio::MemBioSlice::new(pem)?;
                 cvt_p($f(bio.as_ptr(), ::std::ptr::null_mut(), None, ::std::ptr::null_mut()))
                     .map(|p| ::foreign_types::ForeignType::from_ptr(p))
             }

--- a/boring/src/memcmp.rs
+++ b/boring/src/memcmp.rs
@@ -29,7 +29,7 @@
 //! assert!(!eq(&a, &b));
 //! assert!(!eq(&a, &c));
 //! ```
-use ffi;
+use crate::ffi;
 use libc::size_t;
 
 /// Returns `true` iff `a` and `b` contain the same bytes.

--- a/boring/src/nid.rs
+++ b/boring/src/nid.rs
@@ -1,12 +1,12 @@
 //! A collection of numerical identifiers for OpenSSL objects.
-use ffi;
+use crate::ffi;
 use libc::{c_char, c_int};
 
 use std::ffi::CStr;
 use std::str;
 
-use cvt_p;
-use error::ErrorStack;
+use crate::cvt_p;
+use crate::error::ErrorStack;
 
 /// The digest and public-key algorithms associated with a signature.
 pub struct SignatureAlgorithms {

--- a/boring/src/pkcs12.rs
+++ b/boring/src/pkcs12.rs
@@ -1,17 +1,17 @@
 //! PKCS #12 archives.
 
-use ffi;
+use crate::ffi;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use libc::c_int;
 use std::ffi::CString;
 use std::ptr;
 
-use error::ErrorStack;
-use nid::Nid;
-use pkey::{HasPrivate, PKey, PKeyRef, Private};
-use stack::Stack;
-use x509::{X509Ref, X509};
-use {cvt_0i, cvt_p};
+use crate::error::ErrorStack;
+use crate::nid::Nid;
+use crate::pkey::{HasPrivate, PKey, PKeyRef, Private};
+use crate::stack::Stack;
+use crate::x509::{X509Ref, X509};
+use crate::{cvt_0i, cvt_p};
 
 pub const PKCS12_DEFAULT_ITER: c_int = 2048;
 
@@ -203,15 +203,15 @@ impl Pkcs12Builder {
 
 #[cfg(test)]
 mod test {
-    use hash::MessageDigest;
+    use crate::hash::MessageDigest;
     use hex;
 
-    use asn1::Asn1Time;
-    use nid::Nid;
-    use pkey::PKey;
-    use rsa::Rsa;
-    use x509::extension::KeyUsage;
-    use x509::{X509Name, X509};
+    use crate::asn1::Asn1Time;
+    use crate::nid::Nid;
+    use crate::pkey::PKey;
+    use crate::rsa::Rsa;
+    use crate::x509::extension::KeyUsage;
+    use crate::x509::{X509Name, X509};
 
     use super::*;
 

--- a/boring/src/pkcs5.rs
+++ b/boring/src/pkcs5.rs
@@ -1,11 +1,11 @@
-use ffi;
+use crate::ffi;
 use libc::{c_int, c_uint};
 use std::ptr;
 
-use cvt;
-use error::ErrorStack;
-use hash::MessageDigest;
-use symm::Cipher;
+use crate::cvt;
+use crate::error::ErrorStack;
+use crate::hash::MessageDigest;
+use crate::symm::Cipher;
 
 #[derive(Clone, Eq, PartialEq, Hash, Debug)]
 pub struct KeyIvPair {
@@ -139,8 +139,8 @@ pub fn scrypt(
 
 #[cfg(test)]
 mod tests {
-    use hash::MessageDigest;
-    use symm::Cipher;
+    use crate::hash::MessageDigest;
+    use crate::symm::Cipher;
 
     // Test vectors from
     // https://git.lysator.liu.se/nettle/nettle/blob/nettle_3.1.1_release_20150424/testsuite/pbkdf2-test.c

--- a/boring/src/pkey.rs
+++ b/boring/src/pkey.rs
@@ -40,7 +40,7 @@
 //! println!("{:?}", str::from_utf8(pub_key.as_slice()).unwrap());
 //! ```
 
-use ffi;
+use crate::ffi;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use libc::{c_int, c_long};
 use std::ffi::CString;
@@ -48,14 +48,14 @@ use std::fmt;
 use std::mem;
 use std::ptr;
 
-use bio::MemBioSlice;
-use dh::Dh;
-use dsa::Dsa;
-use ec::EcKey;
-use error::ErrorStack;
-use rsa::Rsa;
-use util::{invoke_passwd_cb, CallbackState};
-use {cvt, cvt_p};
+use crate::bio::MemBioSlice;
+use crate::dh::Dh;
+use crate::dsa::Dsa;
+use crate::ec::EcKey;
+use crate::error::ErrorStack;
+use crate::rsa::Rsa;
+use crate::util::{invoke_passwd_cb, CallbackState};
+use crate::{cvt, cvt_p};
 
 /// A tag type indicating that a key only has parameters.
 pub enum Params {}
@@ -480,14 +480,14 @@ impl PKey<Public> {
     }
 }
 
-use ffi::EVP_PKEY_up_ref;
+use crate::ffi::EVP_PKEY_up_ref;
 
 #[cfg(test)]
 mod tests {
-    use ec::EcKey;
-    use nid::Nid;
-    use rsa::Rsa;
-    use symm::Cipher;
+    use crate::ec::EcKey;
+    use crate::nid::Nid;
+    use crate::rsa::Rsa;
+    use crate::symm::Cipher;
 
     use super::*;
 

--- a/boring/src/rand.rs
+++ b/boring/src/rand.rs
@@ -10,11 +10,11 @@
 //! let mut buf = [0; 256];
 //! rand_bytes(&mut buf).unwrap();
 //! ```
-use ffi;
+use crate::ffi;
 use libc::c_int;
 
-use cvt;
-use error::ErrorStack;
+use crate::cvt;
+use crate::error::ErrorStack;
 
 /// Fill buffer with cryptographically strong pseudo-random bytes.
 ///

--- a/boring/src/rsa.rs
+++ b/boring/src/rsa.rs
@@ -23,17 +23,17 @@
 //! let mut buf = vec![0; rsa.size() as usize];
 //! let encrypted_len = rsa.public_encrypt(data, &mut buf, Padding::PKCS1).unwrap();
 //! ```
-use ffi;
+use crate::ffi;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use libc::c_int;
 use std::fmt;
 use std::mem;
 use std::ptr;
 
-use bn::{BigNum, BigNumRef};
-use error::ErrorStack;
-use pkey::{HasPrivate, HasPublic, Private, Public};
-use {cvt, cvt_n, cvt_p};
+use crate::bn::{BigNum, BigNumRef};
+use crate::error::ErrorStack;
+use crate::pkey::{HasPrivate, HasPublic, Private, Public};
+use crate::{cvt, cvt_n, cvt_p};
 
 pub const EVP_PKEY_OP_SIGN: c_int = 1 << 3;
 pub const EVP_PKEY_OP_VERIFY: c_int = 1 << 4;
@@ -689,14 +689,14 @@ impl<T> fmt::Debug for Rsa<T> {
     }
 }
 
-use ffi::{
+use crate::ffi::{
     RSA_get0_crt_params, RSA_get0_factors, RSA_get0_key, RSA_set0_crt_params, RSA_set0_factors,
     RSA_set0_key,
 };
 
 #[cfg(test)]
 mod test {
-    use symm::Cipher;
+    use crate::symm::Cipher;
 
     use super::*;
 

--- a/boring/src/sha.rs
+++ b/boring/src/sha.rs
@@ -43,7 +43,7 @@
 //!     println!("Hash = {}", hex::encode(hash));
 //! }
 //! ```
-use ffi;
+use crate::ffi;
 use libc::c_void;
 use std::mem;
 

--- a/boring/src/sign.rs
+++ b/boring/src/sign.rs
@@ -34,20 +34,20 @@
 //! verifier.update(data2).unwrap();
 //! assert!(verifier.verify(&signature).unwrap());
 //! ```
-use ffi;
+use crate::ffi;
 use foreign_types::ForeignTypeRef;
 use libc::c_int;
 use std::io::{self, Write};
 use std::marker::PhantomData;
 use std::ptr;
 
-use error::ErrorStack;
-use hash::MessageDigest;
-use pkey::{HasPrivate, HasPublic, PKeyRef};
-use rsa::Padding;
-use {cvt, cvt_p};
+use crate::error::ErrorStack;
+use crate::hash::MessageDigest;
+use crate::pkey::{HasPrivate, HasPublic, PKeyRef};
+use crate::rsa::Padding;
+use crate::{cvt, cvt_p};
 
-use ffi::{EVP_MD_CTX_free, EVP_MD_CTX_new};
+use crate::ffi::{EVP_MD_CTX_free, EVP_MD_CTX_new};
 
 /// Salt lengths that must be used with `set_rsa_pss_saltlen`.
 pub struct RsaPssSaltlen(c_int);
@@ -571,19 +571,19 @@ impl<'a> Write for Verifier<'a> {
     }
 }
 
-use ffi::EVP_DigestVerifyFinal;
+use crate::ffi::EVP_DigestVerifyFinal;
 
 #[cfg(test)]
 mod test {
     use super::RsaPssSaltlen;
     use hex::{self, FromHex};
 
-    use ec::{EcGroup, EcKey};
-    use hash::MessageDigest;
-    use nid::Nid;
-    use pkey::PKey;
-    use rsa::{Padding, Rsa};
-    use sign::{Signer, Verifier};
+    use crate::ec::{EcGroup, EcKey};
+    use crate::hash::MessageDigest;
+    use crate::nid::Nid;
+    use crate::pkey::PKey;
+    use crate::rsa::{Padding, Rsa};
+    use crate::sign::{Signer, Verifier};
 
     const INPUT: &str =
         "65794a68624763694f694a53557a49314e694a392e65794a7063334d694f694a71623255694c41304b49434a6c\

--- a/boring/src/srtp.rs
+++ b/boring/src/srtp.rs
@@ -1,7 +1,7 @@
-use ffi;
+use crate::ffi;
+use crate::stack::Stackable;
 use foreign_types::ForeignTypeRef;
 use libc::c_ulong;
-use stack::Stackable;
 use std::ffi::CStr;
 use std::str;
 

--- a/boring/src/ssl/bio.rs
+++ b/boring/src/ssl/bio.rs
@@ -1,4 +1,4 @@
-use ffi::{
+use crate::ffi::{
     self, BIO_clear_retry_flags, BIO_new, BIO_set_retry_read, BIO_set_retry_write, BIO,
     BIO_CTRL_DGRAM_QUERY_MTU, BIO_CTRL_FLUSH,
 };
@@ -10,8 +10,8 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::ptr;
 use std::slice;
 
-use cvt_p;
-use error::ErrorStack;
+use crate::cvt_p;
+use crate::error::ErrorStack;
 
 pub struct StreamState<S> {
     pub stream: S,
@@ -208,7 +208,7 @@ unsafe extern "C" fn destroy<S>(bio: *mut BIO) -> c_int {
     1
 }
 
-use ffi::{BIO_get_data, BIO_set_data, BIO_set_flags, BIO_set_init};
+use crate::ffi::{BIO_get_data, BIO_set_data, BIO_set_flags, BIO_set_init};
 
 #[allow(bad_style)]
 unsafe fn BIO_set_num(_bio: *mut ffi::BIO, _num: c_int) {}

--- a/boring/src/ssl/callbacks.rs
+++ b/boring/src/ssl/callbacks.rs
@@ -1,4 +1,4 @@
-use ffi;
+use crate::ffi;
 use foreign_types::ForeignType;
 use foreign_types::ForeignTypeRef;
 use libc::c_char;
@@ -10,14 +10,14 @@ use std::slice;
 use std::str;
 use std::sync::Arc;
 
-use error::ErrorStack;
-use ssl::AlpnError;
-use ssl::{ClientHello, SelectCertError};
-use ssl::{
+use crate::error::ErrorStack;
+use crate::ssl::AlpnError;
+use crate::ssl::{ClientHello, SelectCertError};
+use crate::ssl::{
     SniError, Ssl, SslAlert, SslContext, SslContextRef, SslRef, SslSession, SslSessionRef,
     SESSION_CTX_INDEX,
 };
-use x509::{X509StoreContext, X509StoreContextRef};
+use crate::x509::{X509StoreContext, X509StoreContextRef};
 
 pub extern "C" fn raw_verify<F>(preverify_ok: c_int, x509_ctx: *mut ffi::X509_STORE_CTX) -> c_int
 where

--- a/boring/src/ssl/connector.rs
+++ b/boring/src/ssl/connector.rs
@@ -1,13 +1,13 @@
 use std::io::{Read, Write};
 use std::ops::{Deref, DerefMut};
 
-use dh::Dh;
-use error::ErrorStack;
-use ssl::{
+use crate::dh::Dh;
+use crate::error::ErrorStack;
+use crate::ssl::{
     HandshakeError, Ssl, SslContext, SslContextBuilder, SslContextRef, SslMethod, SslMode,
     SslOptions, SslRef, SslStream, SslVerifyMode,
 };
-use version;
+use crate::version;
 
 const FFDHE_2048: &str = "
 -----BEGIN DH PARAMETERS-----
@@ -326,7 +326,7 @@ fn setup_verify(ctx: &mut SslContextBuilder) {
 }
 
 fn setup_verify_hostname(ssl: &mut SslRef, domain: &str) -> Result<(), ErrorStack> {
-    use x509::verify::X509CheckFlags;
+    use crate::x509::verify::X509CheckFlags;
 
     let param = ssl.param_mut();
     param.set_hostflags(X509CheckFlags::NO_PARTIAL_WILDCARDS);

--- a/boring/src/ssl/error.rs
+++ b/boring/src/ssl/error.rs
@@ -1,13 +1,13 @@
-use ffi;
+use crate::ffi;
 use libc::c_int;
 use std::error;
 use std::error::Error as StdError;
 use std::fmt;
 use std::io;
 
-use error::ErrorStack;
-use ssl::MidHandshakeSslStream;
-use x509::X509VerifyResult;
+use crate::error::ErrorStack;
+use crate::ssl::MidHandshakeSslStream;
+use crate::x509::X509VerifyResult;
 
 /// An error code returned from SSL functions.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]

--- a/boring/src/ssl/mod.rs
+++ b/boring/src/ssl/mod.rs
@@ -57,7 +57,7 @@
 //!     }
 //! }
 //! ```
-use ffi;
+use crate::ffi;
 use foreign_types::{ForeignType, ForeignTypeRef, Opaque};
 use libc::{c_char, c_int, c_long, c_uchar, c_uint, c_void};
 use std::any::TypeId;
@@ -78,26 +78,26 @@ use std::slice;
 use std::str;
 use std::sync::{Arc, Mutex};
 
-use dh::DhRef;
-use ec::EcKeyRef;
-use error::ErrorStack;
-use ex_data::Index;
-use nid::Nid;
-use pkey::{HasPrivate, PKeyRef, Params, Private};
-use srtp::{SrtpProtectionProfile, SrtpProtectionProfileRef};
-use ssl::bio::BioMethod;
-use ssl::callbacks::*;
-use ssl::error::InnerError;
-use stack::{Stack, StackRef};
-use x509::store::{X509Store, X509StoreBuilderRef, X509StoreRef};
-use x509::verify::X509VerifyParamRef;
-use x509::{X509Name, X509Ref, X509StoreContextRef, X509VerifyResult, X509};
-use {cvt, cvt_0i, cvt_n, cvt_p, init};
+use crate::dh::DhRef;
+use crate::ec::EcKeyRef;
+use crate::error::ErrorStack;
+use crate::ex_data::Index;
+use crate::nid::Nid;
+use crate::pkey::{HasPrivate, PKeyRef, Params, Private};
+use crate::srtp::{SrtpProtectionProfile, SrtpProtectionProfileRef};
+use crate::ssl::bio::BioMethod;
+use crate::ssl::callbacks::*;
+use crate::ssl::error::InnerError;
+use crate::stack::{Stack, StackRef};
+use crate::x509::store::{X509Store, X509StoreBuilderRef, X509StoreRef};
+use crate::x509::verify::X509VerifyParamRef;
+use crate::x509::{X509Name, X509Ref, X509StoreContextRef, X509VerifyResult, X509};
+use crate::{cvt, cvt_0i, cvt_n, cvt_p, init};
 
-pub use ssl::connector::{
+pub use crate::ssl::connector::{
     ConnectConfiguration, SslAcceptor, SslAcceptorBuilder, SslConnector, SslConnectorBuilder,
 };
-pub use ssl::error::{Error, ErrorCode, HandshakeError};
+pub use crate::ssl::error::{Error, ErrorCode, HandshakeError};
 
 mod bio;
 mod callbacks;
@@ -3377,9 +3377,9 @@ bitflags! {
     }
 }
 
-use ffi::{SSL_CTX_up_ref, SSL_SESSION_get_master_key, SSL_SESSION_up_ref, SSL_is_server};
+use crate::ffi::{SSL_CTX_up_ref, SSL_SESSION_get_master_key, SSL_SESSION_up_ref, SSL_is_server};
 
-use ffi::{DTLS_method, TLS_client_method, TLS_method, TLS_server_method};
+use crate::ffi::{DTLS_method, TLS_client_method, TLS_method, TLS_server_method};
 
 use std::sync::Once;
 

--- a/boring/src/ssl/test/mod.rs
+++ b/boring/src/ssl/test/mod.rs
@@ -16,23 +16,23 @@ use std::thread;
 use std::time::Duration;
 use tempdir::TempDir;
 
-use dh::Dh;
-use error::ErrorStack;
-use hash::MessageDigest;
-use pkey::PKey;
-use srtp::SrtpProfileId;
-use ssl;
-use ssl::test::server::Server;
-use ssl::SslVersion;
-use ssl::{
+use crate::dh::Dh;
+use crate::error::ErrorStack;
+use crate::hash::MessageDigest;
+use crate::pkey::PKey;
+use crate::srtp::SrtpProfileId;
+use crate::ssl;
+use crate::ssl::test::server::Server;
+use crate::ssl::SslVersion;
+use crate::ssl::{
     Error, ExtensionType, HandshakeError, MidHandshakeSslStream, ShutdownResult, ShutdownState,
     Ssl, SslAcceptor, SslAcceptorBuilder, SslConnector, SslContext, SslContextBuilder, SslFiletype,
     SslMethod, SslOptions, SslSessionCacheMode, SslStream, SslStreamBuilder, SslVerifyMode,
     StatusType,
 };
-use x509::store::X509StoreBuilder;
-use x509::verify::X509CheckFlags;
-use x509::{X509Name, X509StoreContext, X509VerifyResult, X509};
+use crate::x509::store::X509StoreBuilder;
+use crate::x509::verify::X509CheckFlags;
+use crate::x509::{X509Name, X509StoreContext, X509VerifyResult, X509};
 
 mod server;
 

--- a/boring/src/ssl/test/server.rs
+++ b/boring/src/ssl/test/server.rs
@@ -2,7 +2,7 @@ use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::thread::{self, JoinHandle};
 
-use ssl::{Ssl, SslContext, SslContextBuilder, SslFiletype, SslMethod, SslRef, SslStream};
+use crate::ssl::{Ssl, SslContext, SslContextBuilder, SslFiletype, SslMethod, SslRef, SslStream};
 
 pub struct Server {
     handle: Option<JoinHandle<()>>,

--- a/boring/src/stack.rs
+++ b/boring/src/stack.rs
@@ -1,4 +1,4 @@
-use ffi;
+use crate::ffi;
 use foreign_types::{ForeignType, ForeignTypeRef, Opaque};
 use libc::size_t;
 use std::borrow::Borrow;
@@ -9,10 +9,10 @@ use std::marker::PhantomData;
 use std::mem;
 use std::ops::{Deref, DerefMut, Index, IndexMut, Range};
 
-use error::ErrorStack;
-use {cvt_0, cvt_p};
+use crate::error::ErrorStack;
+use crate::{cvt_0, cvt_p};
 
-use ffi::{
+use crate::ffi::{
     sk_free as OPENSSL_sk_free, sk_new_null as OPENSSL_sk_new_null, sk_num as OPENSSL_sk_num,
     sk_pop as OPENSSL_sk_pop, sk_push as OPENSSL_sk_push, sk_value as OPENSSL_sk_value,
     _STACK as OPENSSL_STACK,

--- a/boring/src/string.rs
+++ b/boring/src/string.rs
@@ -1,4 +1,4 @@
-use ffi;
+use crate::ffi;
 use foreign_types::ForeignTypeRef;
 use libc::{c_char, c_void};
 use std::convert::AsRef;
@@ -7,7 +7,7 @@ use std::fmt;
 use std::ops::Deref;
 use std::str;
 
-use stack::Stackable;
+use crate::stack::Stackable;
 
 foreign_type_and_impl_send_sync! {
     type CType = c_char;
@@ -81,5 +81,5 @@ impl fmt::Debug for OpensslStringRef {
 }
 
 unsafe fn free(buf: *mut c_char) {
-    ::ffi::OPENSSL_free(buf as *mut c_void);
+    crate::ffi::OPENSSL_free(buf as *mut c_void);
 }

--- a/boring/src/symm.rs
+++ b/boring/src/symm.rs
@@ -52,14 +52,14 @@
 //! println!("Decrypted: '{}'", output_string);
 //! ```
 
-use ffi;
+use crate::ffi;
 use libc::{c_int, c_uint};
 use std::cmp;
 use std::ptr;
 
-use error::ErrorStack;
-use nid::Nid;
-use {cvt, cvt_p};
+use crate::error::ErrorStack;
+use crate::nid::Nid;
+use crate::{cvt, cvt_p};
 
 #[derive(Copy, Clone)]
 pub enum Mode {
@@ -684,7 +684,7 @@ pub fn decrypt_aead(
     Ok(out)
 }
 
-use ffi::{EVP_CIPHER_block_size, EVP_CIPHER_iv_length, EVP_CIPHER_key_length};
+use crate::ffi::{EVP_CIPHER_block_size, EVP_CIPHER_iv_length, EVP_CIPHER_key_length};
 
 #[cfg(test)]
 mod tests {

--- a/boring/src/util.rs
+++ b/boring/src/util.rs
@@ -3,7 +3,7 @@ use std::any::Any;
 use std::panic::{self, AssertUnwindSafe};
 use std::slice;
 
-use error::ErrorStack;
+use crate::error::ErrorStack;
 
 /// Wraps a user-supplied callback and a slot for panics thrown inside the callback (while FFI
 /// frames are on the stack).

--- a/boring/src/version.rs
+++ b/boring/src/version.rs
@@ -13,7 +13,7 @@
 
 use std::ffi::CStr;
 
-use ffi::{
+use crate::ffi::{
     OpenSSL_version, OpenSSL_version_num, OPENSSL_BUILT_ON, OPENSSL_CFLAGS, OPENSSL_DIR,
     OPENSSL_PLATFORM, OPENSSL_VERSION,
 };

--- a/boring/src/x509/extension.rs
+++ b/boring/src/x509/extension.rs
@@ -17,9 +17,9 @@
 //! ```
 use std::fmt::Write;
 
-use error::ErrorStack;
-use nid::Nid;
-use x509::{X509Extension, X509v3Context};
+use crate::error::ErrorStack;
+use crate::nid::Nid;
+use crate::x509::{X509Extension, X509v3Context};
 
 /// An extension which indicates whether a certificate is a CA certificate.
 pub struct BasicConstraints {

--- a/boring/src/x509/mod.rs
+++ b/boring/src/x509/mod.rs
@@ -7,7 +7,7 @@
 //! Internet protocols, including SSL/TLS, which is the basis for HTTPS,
 //! the secure protocol for browsing the web.
 
-use ffi;
+use crate::ffi;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use libc::{c_int, c_long};
 use std::convert::TryInto;
@@ -21,18 +21,18 @@ use std::ptr;
 use std::slice;
 use std::str;
 
-use asn1::{Asn1BitStringRef, Asn1IntegerRef, Asn1ObjectRef, Asn1StringRef, Asn1TimeRef};
-use bio::MemBioSlice;
-use conf::ConfRef;
-use error::ErrorStack;
-use ex_data::Index;
-use hash::{DigestBytes, MessageDigest};
-use nid::Nid;
-use pkey::{HasPrivate, HasPublic, PKey, PKeyRef, Public};
-use ssl::SslRef;
-use stack::{Stack, StackRef, Stackable};
-use string::OpensslString;
-use {cvt, cvt_n, cvt_p};
+use crate::asn1::{Asn1BitStringRef, Asn1IntegerRef, Asn1ObjectRef, Asn1StringRef, Asn1TimeRef};
+use crate::bio::MemBioSlice;
+use crate::conf::ConfRef;
+use crate::error::ErrorStack;
+use crate::ex_data::Index;
+use crate::hash::{DigestBytes, MessageDigest};
+use crate::nid::Nid;
+use crate::pkey::{HasPrivate, HasPublic, PKey, PKeyRef, Public};
+use crate::ssl::SslRef;
+use crate::stack::{Stack, StackRef, Stackable};
+use crate::string::OpensslString;
+use crate::{cvt, cvt_n, cvt_p};
 
 pub mod extension;
 pub mod store;
@@ -1418,14 +1418,14 @@ impl Stackable for X509Object {
     type StackType = ffi::stack_st_X509_OBJECT;
 }
 
-use ffi::{X509_get0_signature, X509_getm_notAfter, X509_getm_notBefore, X509_up_ref};
+use crate::ffi::{X509_get0_signature, X509_getm_notAfter, X509_getm_notBefore, X509_up_ref};
 
-use ffi::{
+use crate::ffi::{
     ASN1_STRING_get0_data, X509_ALGOR_get0, X509_REQ_get_subject_name, X509_REQ_get_version,
     X509_STORE_CTX_get0_chain, X509_set1_notAfter, X509_set1_notBefore,
 };
 
-use ffi::X509_OBJECT_get0_X509;
+use crate::ffi::X509_OBJECT_get0_X509;
 
 #[allow(bad_style)]
 unsafe fn X509_OBJECT_free(x: *mut ffi::X509_OBJECT) {

--- a/boring/src/x509/store.rs
+++ b/boring/src/x509/store.rs
@@ -34,14 +34,14 @@
 //! let store: X509Store = builder.build();
 //! ```
 
-use ffi;
+use crate::ffi;
 use foreign_types::ForeignTypeRef;
 use std::mem;
 
-use error::ErrorStack;
-use stack::StackRef;
-use x509::{X509Object, X509};
-use {cvt, cvt_p};
+use crate::error::ErrorStack;
+use crate::stack::StackRef;
+use crate::x509::{X509Object, X509};
+use crate::{cvt, cvt_p};
 
 foreign_type_and_impl_send_sync! {
     type CType = ffi::X509_STORE;
@@ -107,4 +107,4 @@ impl X509StoreRef {
     }
 }
 
-use ffi::X509_STORE_get0_objects;
+use crate::ffi::X509_STORE_get0_objects;

--- a/boring/src/x509/tests.rs
+++ b/boring/src/x509/tests.rs
@@ -1,18 +1,18 @@
 use hex::{self, FromHex};
 
-use asn1::Asn1Time;
-use bn::{BigNum, MsbOption};
-use hash::MessageDigest;
-use nid::Nid;
-use pkey::{PKey, Private};
-use rsa::Rsa;
-use stack::Stack;
-use x509::extension::{
+use crate::asn1::Asn1Time;
+use crate::bn::{BigNum, MsbOption};
+use crate::hash::MessageDigest;
+use crate::nid::Nid;
+use crate::pkey::{PKey, Private};
+use crate::rsa::Rsa;
+use crate::stack::Stack;
+use crate::x509::extension::{
     AuthorityKeyIdentifier, BasicConstraints, ExtendedKeyUsage, KeyUsage, SubjectAlternativeName,
     SubjectKeyIdentifier,
 };
-use x509::store::X509StoreBuilder;
-use x509::{X509Name, X509Req, X509StoreContext, X509VerifyResult, X509};
+use crate::x509::store::X509StoreBuilder;
+use crate::x509::{X509Name, X509Req, X509StoreContext, X509VerifyResult, X509};
 
 fn pkey() -> PKey<Private> {
     let rsa = Rsa::generate(2048).unwrap();

--- a/boring/src/x509/verify.rs
+++ b/boring/src/x509/verify.rs
@@ -1,10 +1,10 @@
-use ffi;
+use crate::ffi;
 use foreign_types::ForeignTypeRef;
 use libc::c_uint;
 use std::net::IpAddr;
 
-use cvt;
-use error::ErrorStack;
+use crate::cvt;
+use crate::error::ErrorStack;
 
 bitflags! {
     /// Flags used to check an `X509` certificate.


### PR DESCRIPTION
I recommend reviewing this by running `cargo fix --edition` locally and making sure the output is the same; I know the diff is giant.

This found a bug in cargo: https://github.com/rust-lang/cargo/issues/9782.