### PR TITLE
Remove PasswordCallback from boring-sys

### DIFF
--- a/boring-sys/src/lib.rs
+++ b/boring-sys/src/lib.rs
@@ -64,14 +64,6 @@ const_fn! {
     }
 }
 
-// FIXME remove
-pub type PasswordCallback = unsafe extern "C" fn(
-    buf: *mut c_char,
-    size: c_int,
-    rwflag: c_int,
-    user_data: *mut c_void,
-) -> c_int;
-
 pub fn init() {
     use std::ptr;
     use std::sync::Once;


### PR DESCRIPTION
I have removed the PasswordCallback. References to this are not present in the repository, but is it ok to delete this directly or should this be marked as `#[deprecated]` first?

Best regards
Robin