### PR TITLE
boring-sys: Disable unnecessary bindgen dependencies

### DIFF
--- a/boring-sys/Cargo.toml
+++ b/boring-sys/Cargo.toml
@@ -27,5 +27,5 @@ include = [
 ]
 
 [build-dependencies]
-bindgen = "0.59"
+bindgen = { version = "0.59", default-features = false, features = ["runtime"] }
 cmake = "0.1"


### PR DESCRIPTION
`bindgen`'s default features include dependencies like `clap` and
`env_logger` which are unnecessary when building `boring-sys`. When
using tools like `cargo-deny` to audit dependencies with mismatched
versions, these dependencies can easily conflict with application
dependencies.

This change disables `bindgen`'s default features to avoid unnecessary
dependencies.