### PR TITLE
Relax constraints on `Display for tokio-boring::HandshakeError`

### DIFF
--- a/tokio-boring/src/lib.rs
+++ b/tokio-boring/src/lib.rs
@@ -318,10 +318,7 @@ where
     }
 }
 
-impl<S> fmt::Display for HandshakeError<S>
-where
-    S: fmt::Debug,
-{
+impl<S> fmt::Display for HandshakeError<S> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&self.0, fmt)
     }


### PR DESCRIPTION
`tokio_boring::HandshakeError` currently requires that the inner stream
implements `Debug` for its `Display` implementation. This constraint is
unnecessary.

This change removes this `Debug` constraint so `HandshakeError` always
implements `Display`.