### PR TITLE
Bump versions for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+## [Unreleased]
+
+## [v2.0.0] - 2021-12-16
+
+### Changed
+
+* Updated `foreign-types` from 0.3 to 0.5. This is technically a breaking change if you used `foreign-types` in your own crate, but in practice this shouldn't have a large impact.
+* Removed unused `*Ref` structs; these served no purpose and were not useful.
+* Removed unused `tempdir` dependency

--- a/boring-sys/CHANGELOG.md
+++ b/boring-sys/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Change Log
+
+## [Unreleased]
+
+## [v2.0.0] - 2021-12-16
+
+### Added
+
+* Allow using pre-built binaries of `bssl` using the `BORING_BSSL_PATH` env variable
+* Automatically fetch the `boringssl` submodule if it doesn't yet exist
+
+### Changed
+
+* Removed unused `PasswordCallback` type
+* Disable unused bindgen dependencies
+* Update `bindgen` and `bytes` dependencies
+* 

--- a/boring-sys/Cargo.toml
+++ b/boring-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "boring-sys"
-version = "1.1.1"
+version = "2.0.0"
 authors = ["Alex Crichton <alex@alexcrichton.com>",
            "Steven Fackler <sfackler@gmail.com>",
            "Ivan Nikulin <ifaaan@gmail.com>"]

--- a/boring/Cargo.toml
+++ b/boring/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "boring"
-version = "1.1.6"
+version = "2.0.0"
 authors = ["Steven Fackler <sfackler@gmail.com>", "Ivan Nikulin <ifaaan@gmail.com>"]
 license = "Apache-2.0"
 description = "BoringSSL bindings"
@@ -16,7 +16,7 @@ bitflags = "1.0"
 foreign-types = "0.5"
 lazy_static = "1"
 libc = "0.2"
-boring-sys = { version = "1.1.0", path = "../boring-sys" }
+boring-sys = { version = ">=1.1.0,<3.0.0", path = "../boring-sys" }
 
 [dev-dependencies]
 hex = "0.4"

--- a/hyper-boring/CHANGELOG.md
+++ b/hyper-boring/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [v2.1.1] - 2021-12-16
+
+### Changed
+
+* Removed unnecessary `boring-sys` and `bytes` dependencies
+
 ## [v0.8.0] - 2019-12-10
 
 ### Changed

--- a/hyper-boring/Cargo.toml
+++ b/hyper-boring/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyper-boring"
-version = "2.1.0"
+version = "2.1.1"
 authors = ["Steven Fackler <sfackler@gmail.com>", "Ivan Nikulin <ifaaan@gmail.com>"]
 edition = "2018"
 description = "Hyper TLS support via BoringSSL"
@@ -21,7 +21,7 @@ http = "0.2"
 hyper = { version = "0.14", default-features = false, features = ["client"] }
 linked_hash_set = "0.1"
 once_cell = "1.0"
-boring = { version = "1.1.0", path = "../boring" }
+boring = { version = ">=1.1.0,<3.0.0", path = "../boring" }
 tokio = "1"
 tokio-boring = { version = "2", path = "../tokio-boring" }
 tower-layer = "0.3"

--- a/tokio-boring/CHANGELOG.md
+++ b/tokio-boring/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Change Log
+
+## [Unreleased]
+
+## [v2.1.4] - 2021-12-16
+
+### Changed
+
+* Removed unnecessary `S: Debug` constraint for `HandshakeError`

--- a/tokio-boring/Cargo.toml
+++ b/tokio-boring/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-boring"
-version = "2.1.3"
+version = "2.1.4"
 authors = ["Alex Crichton <alex@alexcrichton.com>", "Ivan Nikulin <ifaaan@gmail.com>"]
 license = "MIT/Apache-2.0"
 edition = "2018"
@@ -12,8 +12,8 @@ An implementation of SSL streams for Tokio backed by BoringSSL
 """
 
 [dependencies]
-boring = { version = "1.1.0", path = "../boring" }
-boring-sys = { version = "1.1.0", path = "../boring-sys" }
+boring = { version = ">=1.1.0,<3.0.0", path = "../boring" }
+boring-sys = { version = ">=1.1.0,<3.0.0", path = "../boring-sys" }
 tokio = "1"
 
 [dev-dependencies]


### PR DESCRIPTION
Closes https://github.com/cloudflare/boring/issues/54

- Major version for boring-sys: `PasswordCallback` was removed
- Major version for boring: the public `*Ref` types were removed and `foreign-types` appears in our public api and had a major version bump
- Patch version for tokio-boring: the only API change was removing the `S: Debug` bound
- Patch version for hyper-boring: no API changes, only removed dependencies