### PR TITLE
Support cross-compilation for iOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,11 +152,11 @@ jobs:
     - name: Set LIBCLANG_PATH
       if: startsWith(matrix.os, 'windows')
       run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
-    - if: startsWith(matrix.os, 'windows')
+    - if: "startsWith(matrix.os, 'windows') && !contains(matrix.target, 'ios')"
       # CI's Windows doesn't have require root certs
       run: cargo test --workspace --exclude tokio-boring --exclude hyper-boring
       name: Run tests (Windows)
-    - if: "!startsWith(matrix.os, 'windows')"
+    - if: "!startsWith(matrix.os, 'windows') && !contains(matrix.target, 'ios')"
       run: cargo test
       name: Run tests (not Windows)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,9 @@ jobs:
         - arm64-android
         - i686-android
         - x86_64-android
+        - aarch64-ios
+        - aarch64-ios-sim
+        - x86_64-ios
         - i686-linux
         - arm-linux
         - aarch64-linux
@@ -102,6 +105,15 @@ jobs:
           target: x86_64-linux-android
           rust: stable
           os: ubuntu-latest
+        - thing: aarch64-ios
+          target: aarch64-apple-ios
+          os: macos-latest
+        - thing: aarch64-ios-sim
+          target: aarch64-apple-ios-sim
+          os: macos-latest
+        - thing: x86_64-ios
+          target: x86_64-apple-ios
+          os: macos-latest
         - thing: i686-linux
           target: i686-unknown-linux-gnu
           rust: stable
@@ -159,6 +171,11 @@ jobs:
     - if: "!startsWith(matrix.os, 'windows') && !contains(matrix.target, 'ios')"
       run: cargo test
       name: Run tests (not Windows)
+    - if: "contains(matrix.target, 'ios')"
+      # It's... theoretically possible to run tests on iPhone Simulator,
+      # but for now, make sure that BoringSSL only builds.
+      run: cargo check --target ${{ matrix.target }} --all-targets
+      name: Check tests (iOS)
 
   test-fips:
     name: Test FIPS integration

--- a/boring-sys/build.rs
+++ b/boring-sys/build.rs
@@ -354,7 +354,8 @@ fn main() {
     println!("cargo:rustc-link-lib=static=ssl");
 
     // MacOS: Allow cdylib to link with undefined symbols
-    if cfg!(target_os = "macos") {
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
+    if target_os == "macos" {
         println!("cargo:rustc-cdylib-link-arg=-Wl,-undefined,dynamic_lookup");
     }
 

--- a/boring-sys/build.rs
+++ b/boring-sys/build.rs
@@ -65,6 +65,16 @@ const CMAKE_PARAMS_IOS: &[(&str, &[(&str, &str)])] = &[
     ),
 ];
 
+fn cmake_params_ios() -> &'static [(&'static str, &'static str)] {
+    let arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    for (ios_arch, params) in CMAKE_PARAMS_IOS {
+        if *ios_arch == arch {
+            return *params;
+        }
+    }
+    &[]
+}
+
 /// Returns the platform-specific output path for lib.
 ///
 /// MSVC generator on Windows place static libs in a target sub-folder,
@@ -143,13 +153,9 @@ fn get_boringssl_cmake_config() -> cmake::Config {
         }
 
         "ios" => {
-            for (ios_arch, params) in CMAKE_PARAMS_IOS {
-                if *ios_arch == arch {
-                    for (name, value) in *params {
-                        eprintln!("ios arch={} add {}={}", arch, name, value);
-                        boringssl_cmake.define(name, value);
-                    }
-                }
+            for (name, value) in cmake_params_ios() {
+                eprintln!("ios arch={} add {}={}", arch, name, value);
+                boringssl_cmake.define(name, value);
             }
 
             // Bitcode is always on.

--- a/boring-sys/build.rs
+++ b/boring-sys/build.rs
@@ -384,6 +384,22 @@ fn main() {
         .clang_args(get_extra_clang_args_for_bindgen())
         .clang_args(&["-I", &include_path]);
 
+    let target = std::env::var("TARGET").unwrap();
+    match target.as_ref() {
+        // bindgen produces alignment tests that cause undefined behavior [1]
+        // when applied to explicitly unaligned types like OSUnalignedU64.
+        //
+        // There is no way to disable these tests for only some types
+        // and it's not nice to suppress warnings for the entire crate,
+        // so let's disable all alignment tests and hope for the best.
+        //
+        // [1]: https://github.com/rust-lang/rust-bindgen/issues/1651
+        "aarch64-apple-ios" | "aarch64-apple-ios-sim" => {
+            builder = builder.layout_tests(false);
+        }
+        _ => {}
+    }
+
     let headers = [
         "aes.h",
         "asn1_mac.h",

--- a/boring-sys/build.rs
+++ b/boring-sys/build.rs
@@ -50,14 +50,14 @@ fn cmake_params_android() -> &'static [(&'static str, &'static str)] {
 
 const CMAKE_PARAMS_IOS: &[(&str, &[(&str, &str)])] = &[
     (
-        "aarch64",
+        "aarch64-apple-ios",
         &[
             ("CMAKE_OSX_ARCHITECTURES", "arm64"),
             ("CMAKE_OSX_SYSROOT", "iphoneos"),
         ],
     ),
     (
-        "x86_64",
+        "x86_64-apple-ios",
         &[
             ("CMAKE_OSX_ARCHITECTURES", "x86_64"),
             ("CMAKE_OSX_SYSROOT", "iphonesimulator"),
@@ -66,9 +66,9 @@ const CMAKE_PARAMS_IOS: &[(&str, &[(&str, &str)])] = &[
 ];
 
 fn cmake_params_ios() -> &'static [(&'static str, &'static str)] {
-    let arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap();
-    for (ios_arch, params) in CMAKE_PARAMS_IOS {
-        if *ios_arch == arch {
+    let target = std::env::var("TARGET").unwrap();
+    for (ios_target, params) in CMAKE_PARAMS_IOS {
+        if *ios_target == target {
             return *params;
         }
     }

--- a/boring-sys/build.rs
+++ b/boring-sys/build.rs
@@ -57,6 +57,13 @@ const CMAKE_PARAMS_IOS: &[(&str, &[(&str, &str)])] = &[
         ],
     ),
     (
+        "aarch64-apple-ios-sim",
+        &[
+            ("CMAKE_OSX_ARCHITECTURES", "arm64"),
+            ("CMAKE_OSX_SYSROOT", "iphonesimulator"),
+        ],
+    ),
+    (
         "x86_64-apple-ios",
         &[
             ("CMAKE_OSX_ARCHITECTURES", "x86_64"),


### PR DESCRIPTION
There was some prior work for iOS support, but it did not really produce a successful build because running `bindgen` failed on macOS (#22). That's because bindgen tried using macOS headers instead of iOS ones, and those don't really match. Proper `-isysroot` flag needs to be passed to clang invocations made by bindgen, pointing it into the right direction.

- Fix building for all iOS targets that rustc supports:
  - `aarch64-apple-ios` – iOS devices running ARM64
  - `aarch64-apple-ios-sim` – iOS simulator running on Apple M1
  - `x86_64-apple-ios` – iOS simulator running on x86_64
- Teach CI to test building for aforementioned targets
  -  Only `cargo build`, no `cargo test`, since that's *way* more involved.
- Suppress some Clippy warnings so that the build gets green

I don't have M1 hardware so I have no idea whether `aarch64-apple-ios-sim` target actually works. Cargo says it builds though. Testing would be much appreciated.