### PR TITLE
Explicit run mode and `--target` for CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,54 +82,70 @@ jobs:
           target: x86_64-unknown-linux-gnu
           rust: stable
           os: ubuntu-latest
+          test-type: run
         - thing: macos-x86_64
           target: x86_64-apple-darwin
           rust: stable
           os: macos-latest
+          test-type: run
+
         - thing: arm-android
           target: arm-linux-androideabi
           rust: stable
           os: ubuntu-latest
+          test-type: run
         - thing: arm64-android
           target: aarch64-linux-android
           rust: stable
           os: ubuntu-latest
+          test-type: run
         - thing: i686-android
           target: i686-linux-android
           rust: stable
           os: ubuntu-latest
+          test-type: run
         - thing: x86_64-android
           target: x86_64-linux-android
           rust: stable
           os: ubuntu-latest
+          test-type: run
+
         - thing: i686-linux
           target: i686-unknown-linux-gnu
           rust: stable
           os: ubuntu-latest
+          test-type: run
         - thing: arm-linux
           target: arm-unknown-linux-gnueabi
           rust: stable
           os: ubuntu-latest
+          test-type: run
         - thing: aarch64-linux
           target: aarch64-unknown-linux-gnu
           rust: stable
           os: ubuntu-latest
+          test-type: run
         - thing: x86_64-musl
           target: x86_64-unknown-linux-musl
           rust: stable
           os: ubuntu-latest
+          test-type: run
+
         - thing: x86_64-mingw
           target: x86_64-pc-windows-gnu
           rust: stable
           os: ubuntu-latest
+          test-type: run
         - thing: i686-msvc
           target: i686-pc-windows-msvc
           rust: stable-x86_64-msvc
           os: windows-latest
+          test-type: run-without-hyper
         - thing: x86_64-msvc
           target: x86_64-pc-windows-msvc
           rust: stable-x86_64-msvc
           os: windows-latest
+          test-type: run-without-hyper
 
     steps:
     - uses: actions/checkout@v2
@@ -152,10 +168,10 @@ jobs:
     - name: Set LIBCLANG_PATH
       if: startsWith(matrix.os, 'windows')
       run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
-    - if: startsWith(matrix.os, 'windows')
+    - if: matrix.test-type == 'run-without-hyper'
       # CI's Windows doesn't have require root certs
       run: cargo test --workspace --exclude tokio-boring --exclude hyper-boring
       name: Run tests (Windows)
-    - if: "!startsWith(matrix.os, 'windows')"
+    - if: matrix.test-type == 'run'
       run: cargo test
       name: Run tests (not Windows)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
           os: macos-latest
           test-type: run
 
+        # FIXME: these targets fail to compile due to linker mismatch
         - thing: arm-android
           target: arm-linux-androideabi
           rust: stable
@@ -110,6 +111,7 @@ jobs:
           os: ubuntu-latest
           test-type: run
 
+        # FIXME: these targets fail to compile due missing cross-compilers
         - thing: i686-linux
           target: i686-unknown-linux-gnu
           rust: stable
@@ -131,6 +133,8 @@ jobs:
           os: ubuntu-latest
           test-type: run
 
+        # FIXME: mingw target fails to compile due missing cross-compilers
+        # (it fails building on Windows as well, for its own reasons)
         - thing: x86_64-mingw
           target: x86_64-pc-windows-gnu
           rust: stable
@@ -170,8 +174,8 @@ jobs:
       run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
     - if: matrix.test-type == 'run-without-hyper'
       # CI's Windows doesn't have require root certs
-      run: cargo test --workspace --exclude tokio-boring --exclude hyper-boring
+      run: cargo test --target ${{ matrix.target }} --workspace --exclude tokio-boring --exclude hyper-boring
       name: Run tests (Windows)
     - if: matrix.test-type == 'run'
-      run: cargo test
+      run: cargo test --target ${{ matrix.target }}
       name: Run tests (not Windows)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,8 @@ jobs:
           rust: stable
           os: ubuntu-latest
           test-type: run
+        # CI's Windows doesn't have required root certs,
+        # breaking tokio-boring and hyper-boring tests.
         - thing: i686-msvc
           target: i686-pc-windows-msvc
           rust: stable-x86_64-msvc
@@ -173,7 +175,6 @@ jobs:
       if: startsWith(matrix.os, 'windows')
       run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
     - if: matrix.test-type == 'run-without-hyper'
-      # CI's Windows doesn't have require root certs
       run: cargo test --target ${{ matrix.target }} --workspace --exclude tokio-boring --exclude hyper-boring
       name: Run tests (Windows)
     - if: matrix.test-type == 'run'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
       run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
     - if: matrix.test-type == 'run-without-hyper'
       run: cargo test --target ${{ matrix.target }} --workspace --exclude tokio-boring --exclude hyper-boring
-      name: Run tests (Windows)
+      name: Run tests (without hyper)
     - if: matrix.test-type == 'run'
       run: cargo test --target ${{ matrix.target }}
-      name: Run tests (not Windows)
+      name: Run tests


### PR DESCRIPTION
This is a demonstration of issue #62.

I'm not really sure what do you want to do with these tests. Right now they are broken and it's not trivial to fix them. Might as well leave them broken as a reminder, or remove them altogether from `ci.yml` to be re-added when they actually work.