### PR TITLE
boring: `BigNumRef::to_vec_padded()`

### DIFF
--- a/boring/src/bn.rs
+++ b/boring/src/bn.rs
@@ -852,6 +852,36 @@ impl BigNumRef {
         v
     }
 
+    /// Returns a big-endian byte vector representation of the absolute value of `self` padded
+    /// to `pad_to` bytes.
+    ///
+    /// If `pad_to` is less than `self.num_bytes()` then an error is returned.
+    ///
+    /// `self` can be recreated by using `from_slice`.
+    ///
+    /// ```
+    /// # use boring::bn::BigNum;
+    /// let bn = BigNum::from_u32(0x4543).unwrap();
+    ///
+    /// let bn_vec = bn.to_vec_padded(4).unwrap();
+    /// assert_eq!(&bn_vec, &[0, 0, 0x45, 0x43]);
+    ///
+    /// let r = bn.to_vec_padded(1);
+    /// assert!(r.is_err());
+    ///
+    /// let bn = -BigNum::from_u32(0x4543).unwrap();
+    /// let bn_vec = bn.to_vec_padded(4).unwrap();
+    /// assert_eq!(&bn_vec, &[0, 0, 0x45, 0x43]);
+    /// ```
+    pub fn to_vec_padded(&self, pad_to: usize) -> Result<Vec<u8>, ErrorStack> {
+        let mut v = Vec::with_capacity(pad_to);
+        unsafe {
+            cvt(ffi::BN_bn2bin_padded(v.as_mut_ptr(), pad_to, self.as_ptr()))?;
+            v.set_len(pad_to);
+        }
+        Ok(v)
+    }
+
     /// Returns a decimal string representation of `self`.
     ///
     /// ```


### PR DESCRIPTION
Wrap `BN_bn2bin_padded()` which comes useful for exporting fixed-length BIGNUMs, more efficient than padding result of `to_vec()` afterwards.

Note that in OpenSSL the function is called `BN_bn2binpad()` and has a different order of arguments. BoringSSL's BN_bn2bin_padded() also takes the desired length as `size_t`.