### PR TITLE
Update boringssl deps for quiche 0.12.0 compatibility

### DIFF
--- a/boring/src/ssl/mod.rs
+++ b/boring/src/ssl/mod.rs
@@ -486,7 +486,6 @@ impl ExtensionType {
         Self(ffi::TLSEXT_TYPE_application_layer_protocol_negotiation as u16);
     pub const PADDING: Self = Self(ffi::TLSEXT_TYPE_padding as u16);
     pub const EXTENDED_MASTER_SECRET: Self = Self(ffi::TLSEXT_TYPE_extended_master_secret as u16);
-    pub const TOKEN_BINDING: Self = Self(ffi::TLSEXT_TYPE_token_binding as u16);
     #[cfg(not(feature = "fips"))]
     pub const QUIC_TRANSPORT_PARAMETERS_LEGACY: Self =
         Self(ffi::TLSEXT_TYPE_quic_transport_parameters_legacy as u16);
@@ -511,8 +510,6 @@ impl ExtensionType {
     pub const APPLICATION_SETTINGS: Self = Self(ffi::TLSEXT_TYPE_application_settings as u16);
     #[cfg(not(feature = "fips"))]
     pub const ENCRYPTED_CLIENT_HELLO: Self = Self(ffi::TLSEXT_TYPE_encrypted_client_hello as u16);
-    #[cfg(not(feature = "fips"))]
-    pub const ECH_IS_INNER: Self = Self(ffi::TLSEXT_TYPE_ech_is_inner as u16);
     pub const CERTIFICATE_TIMESTAMP: Self = Self(ffi::TLSEXT_TYPE_certificate_timestamp as u16);
     pub const NEXT_PROTO_NEG: Self = Self(ffi::TLSEXT_TYPE_next_proto_neg as u16);
     pub const CHANNEL_ID: Self = Self(ffi::TLSEXT_TYPE_channel_id as u16);
@@ -2507,7 +2504,7 @@ impl SslRef {
             if chain.is_null() {
                 None
             } else {
-                Some(StackRef::from_ptr(chain))
+                Some(StackRef::from_ptr(chain as *mut _))
             }
         }
     }


### PR DESCRIPTION
Latest release of `quiche` (`0.12.0`) [uses boringssl commit: `f1c7534`](https://github.com/cloudflare/quiche/tree/0.12.0/quiche/deps).

This breaks case where one wants to make `quiche` and `boring` rely on the same `quichessl` implementation (via setting `BORING_BSSL_PATH` env var).

```
          ┌───────────┐
    ┌─────┤ User Code ├──────┐
    │     └───────────┘      │
    │                        │
    ▼                   ┌────▼────┐
┌────────┐              │ boring  │ 
│ Quiche │              └────┬────┘
└───┬────┘                   │
    │                   ┌────▼─────┐
    │                   │boring-sys│
    │                   └────┬─────┘
    │     ┌───────────┐      │
    └─────► boringssl │◄─────┘
          └───────────┘
```

That's because of some changes in the public interface of `boringssl`.



In particular,

- ExtensionType::TOKEN_BINDING removed from implementation
https://github.com/google/boringssl/commit/d89ec688f2296f41b4999b9db6e8bfba79c18050
> We didn't end up deploying this. We also never implemented the final
RFC, so what we do have isn't useful for someone who wishes to deploy
it anyway.

- ExtensionType::ECH_IS_INNER removed from implementation
https://github.com/google/boringssl/commit/18b6836b2f6340187a7981c82be9be9d092d36d6
> [...]
> ech_is_inner is now folded into the main encrypted_client_hello code
  point. This works better with some stuff around HRR.

---

This CR is going to update `boringssl` dependency and use the same commit from latest release of `quiche`, adapting the interface changes in the `boring` crate.
