### PR TITLE
boring-sys: Save time by not building the bssl CLI utility

### DIFF
--- a/boring-sys/build.rs
+++ b/boring-sys/build.rs
@@ -263,7 +263,8 @@ fn main() {
             cfg.define("FIPS", "1");
         }
 
-        cfg.build_target("bssl").build().display().to_string()
+        cfg.build_target("ssl").build();
+        cfg.build_target("crypto").build().display().to_string()
     });
 
     let build_path = get_boringssl_platform_output_path();


### PR DESCRIPTION
We only need libcrypto and libssl; nothing in the project uses `bssl`, and it's not exposed to downstream clients.