### PR TITLE
chore: update to bindgen 0.60

### DIFF
--- a/boring-sys/Cargo.toml
+++ b/boring-sys/Cargo.toml
@@ -27,7 +27,7 @@ include = [
 ]
 
 [build-dependencies]
-bindgen = { version = "0.59", default-features = false, features = ["runtime"] }
+bindgen = { version = "0.60", default-features = false, features = ["runtime"] }
 cmake = "0.1"
 
 [features]

--- a/boring-sys/src/lib.rs
+++ b/boring-sys/src/lib.rs
@@ -15,7 +15,6 @@ use std::convert::TryInto;
 use std::ffi::c_void;
 use std::os::raw::{c_char, c_int, c_uint, c_ulong};
 
-#[allow(deref_nullptr)] // TODO: remove this when https://github.com/rust-lang/rust-bindgen/issues/1651 finally gets fixed
 mod generated {
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 }


### PR DESCRIPTION
Notably this release provided a fix for https://github.com/rust-lang/rust-bindgen/issues/1651