### PR TITLE
Use Ninja to build BoringSSL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,8 @@ jobs:
       run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
       shell: bash
     - run: rustup target add ${{ matrix.target }}
+    - name: Install Ninja
+      uses: seanmiddleditch/gha-setup-ninja@v3
     - name: Install nasm
       if: startsWith(matrix.os, 'windows')
       run: choco install nasm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
       - name: Get rust version
         id: rust-version
         run: echo "::set-output name=version::$(rustc --version)"
+      - name: Install Ninja
+        uses: seanmiddleditch/gha-setup-ninja@v3
       - name: Cache cargo index
         uses: actions/cache@v1
         with:
@@ -136,7 +138,7 @@ jobs:
           os: ubuntu-latest
         - thing: i686-msvc
           target: i686-pc-windows-msvc
-          rust: stable-x86_64-msvc
+          rust: stable-i686-msvc
           os: windows-latest
         - thing: x86_64-msvc
           target: x86_64-pc-windows-msvc
@@ -189,6 +191,8 @@ jobs:
     - name: Install Rust (rustup)
       run: rustup update stable --no-self-update && rustup default stable
       shell: bash
+    - name: Install Ninja
+      uses: seanmiddleditch/gha-setup-ninja@v3
     - name: Install Clang-7
       run: sudo apt-get install -y clang-7
     - run: cargo test --features fips


### PR DESCRIPTION
[Ninja build system is recommended by BoringSSL](https://github.com/google/boringssl/blob/master/BUILDING.md). Furthermore, the MSVC generator hack is no longer required, and the MinGW-w64 toolchain on Windows also works, the performance of which is presumably better and even on par with Linux, according to [Agner](https://www.agner.org/optimize/blog/read.php?i=1015) and [simdjson](https://github.com/simdjson/simdjson/blob/master/doc/performance.md).