### PR TITLE
MSVC generator hack should be only applied to MSVC

### DIFF
--- a/boring-sys/build.rs
+++ b/boring-sys/build.rs
@@ -98,7 +98,7 @@ fn get_ios_sdk_name() -> &'static str {
 /// so adjust library location based on platform and build target.
 /// See issue: https://github.com/alexcrichton/cmake-rs/issues/18
 fn get_boringssl_platform_output_path() -> String {
-    if cfg!(windows) {
+    if cfg!(target_env = "msvc") {
         // Code under this branch should match the logic in cmake-rs
         let debug_env_var = std::env::var("DEBUG").expect("DEBUG variable not defined in env");
 


### PR DESCRIPTION
The MSVC generator hack should be only applied to MSVC ABI, thereby making MinGW-w64 toolchain functional.

Related to https://github.com/cloudflare/boring/pull/76
