### PR TITLE
boring: Fix memory leak in `Deriver`

### DIFF
--- a/boring/src/derive.rs
+++ b/boring/src/derive.rs
@@ -14,6 +14,14 @@ pub struct Deriver<'a>(*mut ffi::EVP_PKEY_CTX, PhantomData<&'a ()>);
 unsafe impl<'a> Sync for Deriver<'a> {}
 unsafe impl<'a> Send for Deriver<'a> {}
 
+impl<'a> Drop for Deriver<'a> {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::EVP_PKEY_CTX_free(self.0);
+        }
+    }
+}
+
 #[allow(clippy::len_without_is_empty)]
 impl<'a> Deriver<'a> {
     /// Creates a new `Deriver` using the provided private key.


### PR DESCRIPTION
It looks like there's a missing `Drop` implementation for `Deriver`. There's a `EVP_PKEY_CTX_new` but no corresponding call to `EVP_PKEY_CTX_free`.