### PR TITLE
Put BoringSSL's SSL/TLS support behind a new feature 'ssl'

### DIFF
--- a/boring-sys/Cargo.toml
+++ b/boring-sys/Cargo.toml
@@ -31,5 +31,8 @@ bindgen = { version = "0.60", default-features = false, features = ["runtime"] }
 cmake = "0.1"
 
 [features]
+default = ["ssl"]
+ssl = []
+
 # Use a FIPS-validated version of boringssl.
 fips = []

--- a/boring-sys/build.rs
+++ b/boring-sys/build.rs
@@ -330,7 +330,9 @@ fn main() {
             cfg.define("FIPS", "1");
         }
 
-        cfg.build_target("ssl").build();
+        if cfg!(feature = "ssl") {
+            cfg.build_target("ssl").build();
+        }
         cfg.build_target("crypto").build().display().to_string()
     });
 
@@ -352,7 +354,9 @@ fn main() {
     }
 
     println!("cargo:rustc-link-lib=static=crypto");
-    println!("cargo:rustc-link-lib=static=ssl");
+    if cfg!(feature = "ssl") {
+        println!("cargo:rustc-link-lib=static=ssl");
+    }
 
     // MacOS: Allow cdylib to link with undefined symbols
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();

--- a/boring-sys/src/lib.rs
+++ b/boring-sys/src/lib.rs
@@ -64,18 +64,21 @@ const_fn! {
 }
 
 pub fn init() {
-    use std::ptr;
-    use std::sync::Once;
+    #[cfg(feature = "ssl")]
+    {
+        use std::ptr;
+        use std::sync::Once;
 
-    // explicitly initialize to work around https://github.com/openssl/openssl/issues/3505
-    static INIT: Once = Once::new();
+        // explicitly initialize to work around https://github.com/openssl/openssl/issues/3505
+        static INIT: Once = Once::new();
 
-    let init_options = OPENSSL_INIT_LOAD_SSL_STRINGS;
+        let init_options = OPENSSL_INIT_LOAD_SSL_STRINGS;
 
-    INIT.call_once(|| {
-        assert_eq!(
-            unsafe { OPENSSL_init_ssl(init_options.try_into().unwrap(), ptr::null_mut()) },
-            1
-        )
-    });
+        INIT.call_once(|| {
+            assert_eq!(
+                unsafe { OPENSSL_init_ssl(init_options.try_into().unwrap(), ptr::null_mut()) },
+                1
+            )
+        });
+    }
 }

--- a/boring/Cargo.toml
+++ b/boring/Cargo.toml
@@ -16,12 +16,15 @@ bitflags = "1.0"
 foreign-types = "0.5"
 lazy_static = "1"
 libc = "0.2"
-boring-sys = { version = ">=1.1.0,<3.0.0", path = "../boring-sys" }
+boring-sys = { version = ">=1.1.0,<3.0.0", path = "../boring-sys", default-features = false }
 
 [dev-dependencies]
 hex = "0.4"
 rusty-hook = "^0.11"
 
 [features]
+default = ["ssl"]
+ssl = ["boring-sys/ssl"]
+
 # Use a FIPS-validated version of boringssl.
 fips = ["boring-sys/fips"]

--- a/boring/src/dh.rs
+++ b/boring/src/dh.rs
@@ -82,6 +82,7 @@ impl Dh<Params> {
 
 use crate::ffi::DH_set0_pqg;
 
+#[cfg(feature = "ssl")] // Many of these tests use SslContext to verify the result.
 #[cfg(test)]
 mod tests {
     use crate::bn::BigNum;

--- a/boring/src/lib.rs
+++ b/boring/src/lib.rs
@@ -6,13 +6,7 @@
 extern crate bitflags;
 #[macro_use]
 extern crate foreign_types;
-#[macro_use]
-extern crate lazy_static;
 extern crate boring_sys as ffi;
-extern crate libc;
-
-#[cfg(test)]
-extern crate hex;
 
 #[doc(inline)]
 pub use crate::ffi::init;
@@ -51,6 +45,7 @@ pub mod rsa;
 pub mod sha;
 pub mod sign;
 pub mod srtp;
+#[cfg(feature = "ssl")]
 pub mod ssl;
 pub mod stack;
 pub mod string;

--- a/boring/src/ssl/mod.rs
+++ b/boring/src/ssl/mod.rs
@@ -59,6 +59,7 @@
 //! ```
 use crate::ffi;
 use foreign_types::{ForeignType, ForeignTypeRef, Opaque};
+use lazy_static::lazy_static;
 use libc::{c_char, c_int, c_long, c_uchar, c_uint, c_void};
 use std::any::TypeId;
 use std::cmp;

--- a/boring/src/x509/mod.rs
+++ b/boring/src/x509/mod.rs
@@ -29,6 +29,7 @@ use crate::ex_data::Index;
 use crate::hash::{DigestBytes, MessageDigest};
 use crate::nid::Nid;
 use crate::pkey::{HasPrivate, HasPublic, PKey, PKeyRef, Public};
+#[cfg(feature = "ssl")]
 use crate::ssl::SslRef;
 use crate::stack::{Stack, StackRef, Stackable};
 use crate::string::OpensslString;
@@ -52,6 +53,7 @@ foreign_type_and_impl_send_sync! {
 impl X509StoreContext {
     /// Returns the index which can be used to obtain a reference to the `Ssl` associated with a
     /// context.
+    #[cfg(feature = "ssl")]
     pub fn ssl_idx() -> Result<Index<X509StoreContext, SslRef>, ErrorStack> {
         unsafe { cvt_n(ffi::SSL_get_ex_data_X509_STORE_CTX_idx()).map(|idx| Index::from_raw(idx)) }
     }


### PR DESCRIPTION
BoringSSL vends two libraries: libcrypto and libssl. Some clients don't need the libssl part. With a feature flag, we can skip building it (saving on compile time) and initializing it (saving on code size and a tiny bit of run time).

The new feature is on by default for backwards compatibility.

The one thing I wasn't sure what to do with was CI. Should it be a single alternate configuration, like FIPS, or something more? Do we care about FIPS-without-libssl?