### PR TITLE
Remove uses of `mem::uninitialized`

### DIFF
--- a/boring-sys/build.rs
+++ b/boring-sys/build.rs
@@ -42,7 +42,7 @@ fn cmake_params_android() -> &'static [(&'static str, &'static str)] {
     };
     for (android_arch, params) in cmake_params_android {
         if *android_arch == arch {
-            return *params;
+            return params;
         }
     }
     &[]
@@ -76,7 +76,7 @@ fn cmake_params_ios() -> &'static [(&'static str, &'static str)] {
     let target = std::env::var("TARGET").unwrap();
     for (ios_target, params) in CMAKE_PARAMS_IOS {
         if *ios_target == target {
-            return *params;
+            return params;
         }
     }
     &[]
@@ -85,7 +85,7 @@ fn cmake_params_ios() -> &'static [(&'static str, &'static str)] {
 fn get_ios_sdk_name() -> &'static str {
     for (name, value) in cmake_params_ios() {
         if *name == "CMAKE_OSX_SYSROOT" {
-            return *value;
+            return value;
         }
     }
     let target = std::env::var("TARGET").unwrap();

--- a/boring-sys/src/lib.rs
+++ b/boring-sys/src/lib.rs
@@ -15,6 +15,7 @@ use std::convert::TryInto;
 use std::ffi::c_void;
 use std::os::raw::{c_char, c_int, c_uint, c_ulong};
 
+#[allow(clippy::useless_transmute, clippy::derive_partial_eq_without_eq)]
 mod generated {
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 }

--- a/boring/src/aes.rs
+++ b/boring/src/aes.rs
@@ -39,7 +39,8 @@
 //!
 use crate::ffi;
 use libc::{c_int, c_uint, size_t};
-use std::{mem, ptr};
+use std::mem::MaybeUninit;
+use std::ptr;
 
 /// Provides Error handling for parsing keys.
 #[derive(Debug)]
@@ -59,14 +60,14 @@ impl AesKey {
         unsafe {
             assert!(key.len() <= c_int::max_value() as usize / 8);
 
-            let mut aes_key = mem::uninitialized();
+            let mut aes_key = MaybeUninit::uninit();
             let r = ffi::AES_set_encrypt_key(
                 key.as_ptr() as *const _,
                 key.len() as c_uint * 8,
-                &mut aes_key,
+                aes_key.as_mut_ptr(),
             );
             if r == 0 {
-                Ok(AesKey(aes_key))
+                Ok(AesKey(aes_key.assume_init()))
             } else {
                 Err(KeyError(()))
             }
@@ -83,15 +84,15 @@ impl AesKey {
         unsafe {
             assert!(key.len() <= c_int::max_value() as usize / 8);
 
-            let mut aes_key = mem::uninitialized();
+            let mut aes_key = MaybeUninit::uninit();
             let r = ffi::AES_set_decrypt_key(
                 key.as_ptr() as *const _,
                 key.len() as c_uint * 8,
-                &mut aes_key,
+                aes_key.as_mut_ptr(),
             );
 
             if r == 0 {
-                Ok(AesKey(aes_key))
+                Ok(AesKey(aes_key.assume_init()))
             } else {
                 Err(KeyError(()))
             }

--- a/boring/src/sha.rs
+++ b/boring/src/sha.rs
@@ -45,7 +45,7 @@
 //! ```
 use crate::ffi;
 use libc::c_void;
-use std::mem;
+use std::mem::MaybeUninit;
 
 /// Computes the SHA1 hash of some data.
 ///
@@ -57,9 +57,9 @@ use std::mem;
 #[allow(deprecated)] // https://github.com/rust-lang/rust/issues/63566
 pub fn sha1(data: &[u8]) -> [u8; 20] {
     unsafe {
-        let mut hash: [u8; 20] = mem::uninitialized();
-        ffi::SHA1(data.as_ptr(), data.len(), hash.as_mut_ptr());
-        hash
+        let mut hash: MaybeUninit<[u8; 20]> = MaybeUninit::uninit();
+        ffi::SHA1(data.as_ptr(), data.len(), hash.as_mut_ptr().cast());
+        hash.assume_init()
     }
 }
 
@@ -68,9 +68,9 @@ pub fn sha1(data: &[u8]) -> [u8; 20] {
 #[allow(deprecated)] // https://github.com/rust-lang/rust/issues/63566
 pub fn sha224(data: &[u8]) -> [u8; 28] {
     unsafe {
-        let mut hash: [u8; 28] = mem::uninitialized();
-        ffi::SHA224(data.as_ptr(), data.len(), hash.as_mut_ptr());
-        hash
+        let mut hash: MaybeUninit<[u8; 28]> = MaybeUninit::uninit();
+        ffi::SHA224(data.as_ptr(), data.len(), hash.as_mut_ptr().cast());
+        hash.assume_init()
     }
 }
 
@@ -79,9 +79,9 @@ pub fn sha224(data: &[u8]) -> [u8; 28] {
 #[allow(deprecated)] // https://github.com/rust-lang/rust/issues/63566
 pub fn sha256(data: &[u8]) -> [u8; 32] {
     unsafe {
-        let mut hash: [u8; 32] = mem::uninitialized();
-        ffi::SHA256(data.as_ptr(), data.len(), hash.as_mut_ptr());
-        hash
+        let mut hash: MaybeUninit<[u8; 32]> = MaybeUninit::uninit();
+        ffi::SHA256(data.as_ptr(), data.len(), hash.as_mut_ptr().cast());
+        hash.assume_init()
     }
 }
 
@@ -90,9 +90,9 @@ pub fn sha256(data: &[u8]) -> [u8; 32] {
 #[allow(deprecated)] // https://github.com/rust-lang/rust/issues/63566
 pub fn sha384(data: &[u8]) -> [u8; 48] {
     unsafe {
-        let mut hash: [u8; 48] = mem::uninitialized();
-        ffi::SHA384(data.as_ptr(), data.len(), hash.as_mut_ptr());
-        hash
+        let mut hash: MaybeUninit<[u8; 48]> = MaybeUninit::uninit();
+        ffi::SHA384(data.as_ptr(), data.len(), hash.as_mut_ptr().cast());
+        hash.assume_init()
     }
 }
 
@@ -101,9 +101,9 @@ pub fn sha384(data: &[u8]) -> [u8; 48] {
 #[allow(deprecated)] // https://github.com/rust-lang/rust/issues/63566
 pub fn sha512(data: &[u8]) -> [u8; 64] {
     unsafe {
-        let mut hash: [u8; 64] = mem::uninitialized();
-        ffi::SHA512(data.as_ptr(), data.len(), hash.as_mut_ptr());
-        hash
+        let mut hash: MaybeUninit<[u8; 64]> = MaybeUninit::uninit();
+        ffi::SHA512(data.as_ptr(), data.len(), hash.as_mut_ptr().cast());
+        hash.assume_init()
     }
 }
 
@@ -129,9 +129,9 @@ impl Sha1 {
     #[allow(deprecated)] // https://github.com/rust-lang/rust/issues/63566
     pub fn new() -> Sha1 {
         unsafe {
-            let mut ctx = mem::uninitialized();
-            ffi::SHA1_Init(&mut ctx);
-            Sha1(ctx)
+            let mut ctx = MaybeUninit::uninit();
+            ffi::SHA1_Init(ctx.as_mut_ptr());
+            Sha1(ctx.assume_init())
         }
     }
 
@@ -150,9 +150,9 @@ impl Sha1 {
     #[allow(deprecated)] // https://github.com/rust-lang/rust/issues/63566
     pub fn finish(mut self) -> [u8; 20] {
         unsafe {
-            let mut hash: [u8; 20] = mem::uninitialized();
-            ffi::SHA1_Final(hash.as_mut_ptr(), &mut self.0);
-            hash
+            let mut hash: MaybeUninit<[u8; 20]> = MaybeUninit::uninit();
+            ffi::SHA1_Final(hash.as_mut_ptr().cast(), &mut self.0);
+            hash.assume_init()
         }
     }
 }
@@ -174,9 +174,9 @@ impl Sha224 {
     #[allow(deprecated)] // https://github.com/rust-lang/rust/issues/63566
     pub fn new() -> Sha224 {
         unsafe {
-            let mut ctx = mem::uninitialized();
-            ffi::SHA224_Init(&mut ctx);
-            Sha224(ctx)
+            let mut ctx = MaybeUninit::uninit();
+            ffi::SHA224_Init(ctx.as_mut_ptr());
+            Sha224(ctx.assume_init())
         }
     }
 
@@ -195,9 +195,9 @@ impl Sha224 {
     #[allow(deprecated)] // https://github.com/rust-lang/rust/issues/63566
     pub fn finish(mut self) -> [u8; 28] {
         unsafe {
-            let mut hash: [u8; 28] = mem::uninitialized();
-            ffi::SHA224_Final(hash.as_mut_ptr(), &mut self.0);
-            hash
+            let mut hash: MaybeUninit<[u8; 28]> = MaybeUninit::uninit();
+            ffi::SHA224_Final(hash.as_mut_ptr().cast(), &mut self.0);
+            hash.assume_init()
         }
     }
 }
@@ -219,9 +219,9 @@ impl Sha256 {
     #[allow(deprecated)] // https://github.com/rust-lang/rust/issues/63566
     pub fn new() -> Sha256 {
         unsafe {
-            let mut ctx = mem::uninitialized();
-            ffi::SHA256_Init(&mut ctx);
-            Sha256(ctx)
+            let mut ctx = MaybeUninit::uninit();
+            ffi::SHA256_Init(ctx.as_mut_ptr());
+            Sha256(ctx.assume_init())
         }
     }
 
@@ -240,9 +240,9 @@ impl Sha256 {
     #[allow(deprecated)] // https://github.com/rust-lang/rust/issues/63566
     pub fn finish(mut self) -> [u8; 32] {
         unsafe {
-            let mut hash: [u8; 32] = mem::uninitialized();
-            ffi::SHA256_Final(hash.as_mut_ptr(), &mut self.0);
-            hash
+            let mut hash: MaybeUninit<[u8; 32]> = MaybeUninit::uninit();
+            ffi::SHA256_Final(hash.as_mut_ptr().cast(), &mut self.0);
+            hash.assume_init()
         }
     }
 }
@@ -264,9 +264,9 @@ impl Sha384 {
     #[allow(deprecated)] // https://github.com/rust-lang/rust/issues/63566
     pub fn new() -> Sha384 {
         unsafe {
-            let mut ctx = mem::uninitialized();
-            ffi::SHA384_Init(&mut ctx);
-            Sha384(ctx)
+            let mut ctx = MaybeUninit::uninit();
+            ffi::SHA384_Init(ctx.as_mut_ptr());
+            Sha384(ctx.assume_init())
         }
     }
 
@@ -285,9 +285,9 @@ impl Sha384 {
     #[allow(deprecated)] // https://github.com/rust-lang/rust/issues/63566
     pub fn finish(mut self) -> [u8; 48] {
         unsafe {
-            let mut hash: [u8; 48] = mem::uninitialized();
-            ffi::SHA384_Final(hash.as_mut_ptr(), &mut self.0);
-            hash
+            let mut hash: MaybeUninit<[u8; 48]> = MaybeUninit::uninit();
+            ffi::SHA384_Final(hash.as_mut_ptr().cast(), &mut self.0);
+            hash.assume_init()
         }
     }
 }
@@ -309,9 +309,9 @@ impl Sha512 {
     #[allow(deprecated)] // https://github.com/rust-lang/rust/issues/63566
     pub fn new() -> Sha512 {
         unsafe {
-            let mut ctx = mem::uninitialized();
-            ffi::SHA512_Init(&mut ctx);
-            Sha512(ctx)
+            let mut ctx = MaybeUninit::uninit();
+            ffi::SHA512_Init(ctx.as_mut_ptr());
+            Sha512(ctx.assume_init())
         }
     }
 
@@ -330,9 +330,9 @@ impl Sha512 {
     #[allow(deprecated)] // https://github.com/rust-lang/rust/issues/63566
     pub fn finish(mut self) -> [u8; 64] {
         unsafe {
-            let mut hash: [u8; 64] = mem::uninitialized();
-            ffi::SHA512_Final(hash.as_mut_ptr(), &mut self.0);
-            hash
+            let mut hash: MaybeUninit<[u8; 64]> = MaybeUninit::uninit();
+            ffi::SHA512_Final(hash.as_mut_ptr().cast(), &mut self.0);
+            hash.assume_init()
         }
     }
 }

--- a/boring/src/ssl/bio.rs
+++ b/boring/src/ssl/bio.rs
@@ -200,7 +200,7 @@ unsafe extern "C" fn destroy<S>(bio: *mut BIO) -> c_int {
     let data = BIO_get_data(bio);
 
     if !data.is_null() {
-        Box::<StreamState<S>>::from_raw(data as *mut _);
+        drop(Box::<StreamState<S>>::from_raw(data as *mut _));
         BIO_set_data(bio, ptr::null_mut());
     }
 

--- a/boring/src/ssl/connector.rs
+++ b/boring/src/ssl/connector.rs
@@ -100,7 +100,7 @@ impl SslConnector {
 
     /// Returns a shared reference to the inner raw `SslContext`.
     pub fn context(&self) -> &SslContextRef {
-        &*self.0
+        &self.0
     }
 }
 
@@ -293,7 +293,7 @@ impl SslAcceptor {
 
     /// Returns a shared reference to the inner raw `SslContext`.
     pub fn context(&self) -> &SslContextRef {
-        &*self.0
+        &self.0
     }
 }
 

--- a/boring/src/ssl/mod.rs
+++ b/boring/src/ssl/mod.rs
@@ -422,7 +422,7 @@ unsafe extern "C" fn free_data_box<T>(
     _argp: *mut c_void,
 ) {
     if !ptr.is_null() {
-        Box::<T>::from_raw(ptr as *mut T);
+        drop(Box::<T>::from_raw(ptr as *mut T));
     }
 }
 

--- a/boring/src/stack.rs
+++ b/boring/src/stack.rs
@@ -79,13 +79,13 @@ impl<T: Stackable> iter::IntoIterator for Stack<T> {
 
 impl<T: Stackable> AsRef<StackRef<T>> for Stack<T> {
     fn as_ref(&self) -> &StackRef<T> {
-        &*self
+        self
     }
 }
 
 impl<T: Stackable> Borrow<StackRef<T>> for Stack<T> {
     fn borrow(&self) -> &StackRef<T> {
-        &*self
+        self
     }
 }
 

--- a/boring/src/string.rs
+++ b/boring/src/string.rs
@@ -34,7 +34,7 @@ impl Stackable for OpensslString {
 
 impl AsRef<str> for OpensslString {
     fn as_ref(&self) -> &str {
-        &**self
+        self
     }
 }
 
@@ -57,7 +57,7 @@ impl Deref for OpensslStringRef {
 
 impl AsRef<str> for OpensslStringRef {
     fn as_ref(&self) -> &str {
-        &*self
+        self
     }
 }
 


### PR DESCRIPTION
According to [the docs](https://doc.rust-lang.org/stable/std/mem/fn.uninitialized.html),

> Calling this when the content is not yet fully initialized causes immediate undefined behavior.
> it [is] undefined behavior to have uninitialized data in a variable even if that variable has an integer type.

Using MaybeUninit instead, as recommended by the official documentation, avoids undefined behavior by not creating a `&mut` reference to uninitialized data.

This also fixes some harmless clippy warnings.