### PR TITLE
Allow overriding the link search path for `crypto` and `ssl` libraries

### DIFF
--- a/boring-sys/build.rs
+++ b/boring-sys/build.rs
@@ -363,22 +363,28 @@ fn main() {
         cfg.build_target("crypto").build().display().to_string()
     });
 
-    let build_path = get_boringssl_platform_output_path();
-    if cfg!(feature = "fips") {
-        println!(
-            "cargo:rustc-link-search=native={}/build/crypto/{}",
-            bssl_dir, build_path
-        );
-        println!(
-            "cargo:rustc-link-search=native={}/build/ssl/{}",
-            bssl_dir, build_path
-        );
+    println!("cargo:rerun-if-env-changed=BORING_BSSL_NATIVE_SEARCH_PATH");
+    if let Ok(native_search_path) = std::env::var("BORING_BSSL_NATIVE_SEARCH_PATH") {
+        println!("cargo:rustc-link-search=native={}", native_search_path)
     } else {
-        println!(
-            "cargo:rustc-link-search=native={}/build/{}",
-            bssl_dir, build_path
-        );
+        let build_path = get_boringssl_platform_output_path();
+        if cfg!(feature = "fips") {
+            println!(
+                "cargo:rustc-link-search=native={}/build/crypto/{}",
+                bssl_dir, build_path
+            );
+            println!(
+                "cargo:rustc-link-search=native={}/build/ssl/{}",
+                bssl_dir, build_path
+            );
+        } else {
+            println!(
+                "cargo:rustc-link-search=native={}/build/{}",
+                bssl_dir, build_path
+            );
+        }
     }
+
 
     println!("cargo:rustc-link-lib=static=crypto");
     println!("cargo:rustc-link-lib=static=ssl");


### PR DESCRIPTION
Currently, Boring hardlinks the search folder for `crypto` and `ssl` shared objects as build output subfolders under BORING_BSSL_PATH. However, if BORING_BSSL_PATH is set to point to a pre-built binary, the shared objects don't need to live in the build output folder - and likely won't. 

This commit allows overriding the search folder independently of BORING_BSSL_PATH.