### PR TITLE
Implement AsRawFd for SslStream to return -1

### DIFF
--- a/boring/src/ssl/mod.rs
+++ b/boring/src/ssl/mod.rs
@@ -71,6 +71,7 @@ use std::io::prelude::*;
 use std::marker::PhantomData;
 use std::mem::{self, ManuallyDrop};
 use std::ops::{Deref, DerefMut};
+use std::os::unix::prelude::{AsRawFd, RawFd};
 use std::panic::resume_unwind;
 use std::path::Path;
 use std::ptr::{self, NonNull};
@@ -2962,7 +2963,6 @@ where
             .finish()
     }
 }
-
 impl<S: Read + Write> SslStream<S> {
     fn new_base(ssl: Ssl, stream: S) -> Self {
         unsafe {
@@ -3188,6 +3188,13 @@ impl<S: Read + Write> Write for SslStream<S> {
 
     fn flush(&mut self) -> io::Result<()> {
         self.get_mut().flush()
+    }
+}
+
+impl<S> AsRawFd for SslStream<S> {
+    /// SslStream manipulates bytestream so this function will return -1
+    fn as_raw_fd(&self) -> RawFd {
+        -1
     }
 }
 

--- a/tokio-boring/src/lib.rs
+++ b/tokio-boring/src/lib.rs
@@ -21,6 +21,7 @@ use std::error::Error;
 use std::fmt;
 use std::future::Future;
 use std::io::{self, Read, Write};
+use std::os::unix::prelude::{AsRawFd, RawFd};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
@@ -197,6 +198,13 @@ where
     pub unsafe fn from_raw_parts(ssl: *mut ffi::SSL, stream: S) -> Self {
         let stream = StreamWrapper { stream, context: 0 };
         SslStream(ssl::SslStream::from_raw_parts(ssl, stream))
+    }
+}
+
+impl<S> AsRawFd for SslStream<S> {
+    /// SslStream manipulates bytestream so this function will return -1
+    fn as_raw_fd(&self) -> RawFd {
+        self.0.as_raw_fd()
     }
 }
 


### PR DESCRIPTION
Per internal discussion with @inikulin, we should be able to return -1 as the raw fd of SslStream