### PR TITLE
deps: bindgen 0.60 -> 0.64

### DIFF
--- a/boring-sys/Cargo.toml
+++ b/boring-sys/Cargo.toml
@@ -27,7 +27,7 @@ include = [
 ]
 
 [build-dependencies]
-bindgen = { version = "0.60", default-features = false, features = ["runtime"] }
+bindgen = { version = "0.64", default-features = false, features = ["runtime"] }
 cmake = "0.1"
 
 [features]

--- a/boring-sys/build.rs
+++ b/boring-sys/build.rs
@@ -403,7 +403,10 @@ fn main() {
         .derive_debug(true)
         .derive_default(true)
         .derive_eq(true)
-        .default_enum_style(bindgen::EnumVariation::NewType { is_bitfield: false })
+        .default_enum_style(bindgen::EnumVariation::NewType {
+            is_bitfield: false,
+            is_global: false,
+        })
         .default_macro_constant_type(bindgen::MacroTypeVariation::Signed)
         .generate_comments(true)
         .fit_macro_constants(false)


### PR DESCRIPTION
Bindgen 0.60 is 8 months old now and updating notably brings forward compat fixes for more recent
clang/libclang versions (clang 15, the one used by Rust currently).

This changes the MSRV to 1.57 I believe (because of `regex`).