### PR TITLE
Update boringssl to latest upstream commit (fixes #100)

### DIFF
--- a/boring/src/bio.rs
+++ b/boring/src/bio.rs
@@ -1,6 +1,5 @@
 use crate::ffi;
 use crate::ffi::BIO_new_mem_buf;
-use libc::c_int;
 use std::marker::PhantomData;
 use std::ptr;
 use std::slice;
@@ -20,13 +19,18 @@ impl<'a> Drop for MemBioSlice<'a> {
 
 impl<'a> MemBioSlice<'a> {
     pub fn new(buf: &'a [u8]) -> Result<MemBioSlice<'a>, ErrorStack> {
+        #[cfg(not(feature = "fips"))]
+        type BufLen = isize;
+        #[cfg(feature = "fips")]
+        type BufLen = libc::c_int;
+
         ffi::init();
 
-        assert!(buf.len() <= c_int::max_value() as usize);
+        assert!(buf.len() <= BufLen::max_value() as usize);
         let bio = unsafe {
             cvt_p(BIO_new_mem_buf(
                 buf.as_ptr() as *const _,
-                buf.len() as c_int,
+                buf.len() as BufLen,
             ))?
         };
 

--- a/boring/src/ssl/mod.rs
+++ b/boring/src/ssl/mod.rs
@@ -625,8 +625,6 @@ impl SslCurve {
     pub const SECP521R1: SslCurve = SslCurve(ffi::NID_secp521r1);
 
     pub const X25519: SslCurve = SslCurve(ffi::NID_X25519);
-
-    pub const CECPQ2: SslCurve = SslCurve(ffi::NID_CECPQ2);
 }
 
 /// A standard implementation of protocol selection for Application Layer Protocol Negotiation
@@ -1169,11 +1167,14 @@ impl SslContextBuilder {
     /// [`SSL_CTX_set_alpn_protos`]: https://www.openssl.org/docs/man1.1.0/ssl/SSL_CTX_set_alpn_protos.html
     pub fn set_alpn_protos(&mut self, protocols: &[u8]) -> Result<(), ErrorStack> {
         unsafe {
-            assert!(protocols.len() <= c_uint::max_value() as usize);
+            #[cfg_attr(not(feature = "fips"), allow(clippy::unnecessary_cast))]
+            {
+                assert!(protocols.len() <= ProtosLen::max_value() as usize);
+            }
             let r = ffi::SSL_CTX_set_alpn_protos(
                 self.as_ptr(),
                 protocols.as_ptr(),
-                protocols.len() as c_uint,
+                protocols.len() as ProtosLen,
             );
             // fun fact, SSL_CTX_set_alpn_protos has a reversed return code D:
             if r == 0 {
@@ -1772,6 +1773,11 @@ impl SslContextRef {
     }
 }
 
+#[cfg(not(feature = "fips"))]
+type ProtosLen = usize;
+#[cfg(feature = "fips")]
+type ProtosLen = libc::c_uint;
+
 /// Information about the state of a cipher.
 pub struct CipherBits {
     /// The number of secret bits used for the cipher.
@@ -2270,11 +2276,14 @@ impl SslRef {
     /// [`SSL_set_alpn_protos`]: https://www.openssl.org/docs/man1.1.0/ssl/SSL_set_alpn_protos.html
     pub fn set_alpn_protos(&mut self, protocols: &[u8]) -> Result<(), ErrorStack> {
         unsafe {
-            assert!(protocols.len() <= c_uint::max_value() as usize);
+            #[cfg_attr(not(feature = "fips"), allow(clippy::unnecessary_cast))]
+            {
+                assert!(protocols.len() <= ProtosLen::max_value() as usize);
+            }
             let r = ffi::SSL_set_alpn_protos(
                 self.as_ptr(),
                 protocols.as_ptr(),
-                protocols.len() as c_uint,
+                protocols.len() as ProtosLen,
             );
             // fun fact, SSL_set_alpn_protos has a reversed return code D:
             if r == 0 {

--- a/boring/src/x509/mod.rs
+++ b/boring/src/x509/mod.rs
@@ -812,13 +812,13 @@ impl X509NameBuilder {
     pub fn append_entry_by_text(&mut self, field: &str, value: &str) -> Result<(), ErrorStack> {
         unsafe {
             let field = CString::new(field).unwrap();
-            assert!(value.len() <= c_int::max_value() as usize);
+            assert!(value.len() <= ValueLen::max_value() as usize);
             cvt(ffi::X509_NAME_add_entry_by_txt(
                 self.0.as_ptr(),
                 field.as_ptr() as *mut _,
                 ffi::MBSTRING_UTF8,
                 value.as_ptr(),
-                value.len() as c_int,
+                value.len() as ValueLen,
                 -1,
                 0,
             ))
@@ -833,13 +833,13 @@ impl X509NameBuilder {
     /// [`X509_NAME_add_entry_by_NID`]: https://www.openssl.org/docs/man1.1.0/crypto/X509_NAME_add_entry_by_NID.html
     pub fn append_entry_by_nid(&mut self, field: Nid, value: &str) -> Result<(), ErrorStack> {
         unsafe {
-            assert!(value.len() <= c_int::max_value() as usize);
+            assert!(value.len() <= ValueLen::max_value() as usize);
             cvt(ffi::X509_NAME_add_entry_by_NID(
                 self.0.as_ptr(),
                 field.as_raw(),
                 ffi::MBSTRING_UTF8,
                 value.as_ptr() as *mut _,
-                value.len() as c_int,
+                value.len() as ValueLen,
                 -1,
                 0,
             ))
@@ -852,6 +852,11 @@ impl X509NameBuilder {
         self.0
     }
 }
+
+#[cfg(not(feature = "fips"))]
+type ValueLen = isize;
+#[cfg(feature = "fips")]
+type ValueLen = i32;
 
 foreign_type_and_impl_send_sync! {
     type CType = ffi::X509_NAME;

--- a/boring/src/x509/store.rs
+++ b/boring/src/x509/store.rs
@@ -8,6 +8,7 @@
 //! ```rust
 //! use boring::x509::store::{X509StoreBuilder, X509Store};
 //! use boring::x509::{X509, X509Name};
+//! use boring::asn1::Asn1Time;
 //! use boring::pkey::PKey;
 //! use boring::hash::MessageDigest;
 //! use boring::rsa::Rsa;
@@ -22,10 +23,15 @@
 //! let name = name.build();
 //! let mut builder = X509::builder().unwrap();
 //!
+//! // Sep 27th, 2016
+//! let sample_time = Asn1Time::from_unix(1474934400).unwrap();
+//!
 //! builder.set_version(2).unwrap();
 //! builder.set_subject_name(&name).unwrap();
 //! builder.set_issuer_name(&name).unwrap();
 //! builder.set_pubkey(&pkey).unwrap();
+//! builder.set_not_before(&sample_time);
+//! builder.set_not_after(&sample_time);
 //! builder.sign(&pkey, MessageDigest::sha256()).unwrap();
 //!
 //! let certificate: X509 = builder.build();

--- a/boring/src/x509/tests.rs
+++ b/boring/src/x509/tests.rs
@@ -260,7 +260,7 @@ fn x509_req_builder() {
     let name = name.build();
 
     let mut builder = X509Req::builder().unwrap();
-    builder.set_version(2).unwrap();
+    builder.set_version(0).unwrap();
     builder.set_subject_name(&name).unwrap();
     builder.set_pubkey(&pkey).unwrap();
 


### PR DESCRIPTION
Notable commits that cause code changes here:

X509 fields notBefore and notAfter need to be specified
https://boringssl-review.googlesource.com/c/boringssl/+/49349

X509ReqBuilder only accepts X509v1 now
https://boringssl-review.googlesource.com/c/boringssl/+/52605

Some functions switched from int to size_t
https://boringssl-review.googlesource.com/c/boringssl/+/54985

CECPQ2 support was dropped
https://boringssl-review.googlesource.com/c/boringssl/+/58645

This is a breaking change.