### PR TITLE
Bump bindgen to 0.66.1

### DIFF
--- a/boring-sys/Cargo.toml
+++ b/boring-sys/Cargo.toml
@@ -27,7 +27,7 @@ include = [
 ]
 
 [build-dependencies]
-bindgen = { version = "0.65.1", default-features = false, features = ["runtime"] }
+bindgen = { version = "0.66.1", default-features = false, features = ["runtime"] }
 cmake = "0.1"
 
 [features]


### PR DESCRIPTION
Fixes building on clang 16 (https://github.com/cloudflare/boring/issues/124)