### PR TITLE
Adding hmac.h to included headers

### DIFF
--- a/boring-sys/build.rs
+++ b/boring-sys/build.rs
@@ -648,6 +648,7 @@ fn main() {
         "des.h",
         "dtls1.h",
         "hkdf.h",
+        "hmac.h",
         "hrss.h",
         "md4.h",
         "md5.h",


### PR DESCRIPTION
This was originally going to be fixed by #101, however that PR was closed and superseded by #117, which was missing this fix.

The original problem was caused by #97, which updated boringssl to a version that included [a change that removed hmac.h from ssl.h](https://github.com/google/boringssl/commit/05b360d797353dd19842aa5a38dbccbf1c867f21).

This PR adds an include for hmac.h, so it is again available through boring-sys.