### PR TITLE
Fix builds for features that require git patches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "3.0.0"
+version = "3.0.1"
 repository = "https://github.com/cloudflare/boring"
 edition = "2021"
 
@@ -19,6 +19,7 @@ tokio-boring = { version = "3.0", path = "./tokio-boring" }
 
 bindgen = { version = "0.66.1", default-features = false, features = ["runtime"] }
 cmake = "0.1"
+fs_extra = "1.3.0"
 fslock = "0.2"
 bitflags = "1.0"
 foreign-types = "0.5"

--- a/boring-sys/Cargo.toml
+++ b/boring-sys/Cargo.toml
@@ -18,20 +18,27 @@ include = [
     "/LICENSE-MIT",
     "/deps/boringssl/**/*.[chS]",
     "/deps/boringssl/**/*.asm",
-    "/deps/boringssl/src/**/*.cc",
+    "/deps/boringssl/**/*.json",
+    "/deps/boringssl/**/*.num",
+    "/deps/boringssl/**/*.txt",
+    "/deps/boringssl/**/*.bzl",
+    "/deps/boringssl/**/*.cc",
     "/deps/boringssl/**/CMakeLists.txt",
     "/deps/boringssl/**/sources.cmake",
     "/deps/boringssl/LICENSE",
     "/deps/boringssl-fips/**/*.[chS]",
     "/deps/boringssl-fips/**/*.asm",
-    "/deps/boringssl-fips/src/**/*.cc",
+    "/deps/boringssl/**/*.json",
+    "/deps/boringssl/**/*.num",
+    "/deps/boringssl/**/*.txt",
+    "/deps/boringssl-fips/**/*.bzl",
+    "/deps/boringssl-fips/**/*.cc",
     "/deps/boringssl-fips/**/CMakeLists.txt",
     "/deps/boringssl-fips/**/sources.cmake",
     "/deps/boringssl/LICENSE",
     "/build.rs",
     "/src",
     "/patches",
-    "/scripts"
 ]
 
 [package.metadata.docs.rs]
@@ -54,4 +61,5 @@ pq-experimental = []
 [build-dependencies]
 bindgen = { workspace = true }
 cmake = { workspace = true }
+fs_extra = { workspace = true }
 fslock = { workspace = true }

--- a/boring-sys/scripts/apply_pq_patch.sh
+++ b/boring-sys/scripts/apply_pq_patch.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-set -euo pipefail
-
-git apply -v --whitespace=fix ../../patches/boring-pq.patch

--- a/boring-sys/scripts/apply_rpk_patch.sh
+++ b/boring-sys/scripts/apply_rpk_patch.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-set -euo pipefail
-
-git apply -v --whitespace=fix ../../patches/rpk.patch


### PR DESCRIPTION
Previously we were building from the deps directory with submodules. For publishing we were copying files in sumbodules into the package. With this we were making the package directory dirty with build artifacts and applied patches.

This commit change the build script's behaviour: sources are now copied to the output directory and then boringssl is built from there.

In addition, this commit adds files that were missing from the package for building with patches.