### PR TITLE
Fix missing .trim() when verifying FIPS module name.

### DIFF
--- a/boring-sys/build.rs
+++ b/boring-sys/build.rs
@@ -558,7 +558,7 @@ fn link_in_precompiled_bcm_o(bssl_dir: &str) {
     let out = run_command(Command::new("ar").args(["t", &libcrypto_path, "bcm.o"])).unwrap();
 
     assert_eq!(
-        String::from_utf8(out.stdout).unwrap(),
+        String::from_utf8(out.stdout).unwrap().trim(),
         "bcm.o",
         "failed to verify FIPS module name"
     );


### PR DESCRIPTION
Quick fix: addresses a missing `.trim()` in `boring-sys/build.rs`, which causes builds with the `fips-link-precompiled` feature enabled to fail:

```
thread 'main' panicked at 'assertion failed: `(left == right)`
    left: `"bcm.o\n"`,
   right: `"bcm.o"`: failed to verify FIPS module name', /home/mmunoz/.cargo/registry/src/index.crates.io-6f17d22bba15001f/boring-sys-3.0.2/build.rs:560:5
``` 