### PR TITLE
Use features to set key exchange preferences

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,3 +238,5 @@ jobs:
       name: Run `pq-experimental` tests
     - run: cargo test --features pq-experimental,rpk
       name: Run `pq-experimental,rpk` tests
+    - run: cargo test --features kx-safe-default,pq-experimental
+      name: Run `kx-safe-default` tests

--- a/boring-sys/Cargo.toml
+++ b/boring-sys/Cargo.toml
@@ -63,7 +63,11 @@ fips-link-precompiled = []
 # Enables Raw public key API (https://datatracker.ietf.org/doc/html/rfc7250)
 rpk = []
 
-# Enables experimental post-quantum crypto (https://blog.cloudflare.com/post-quantum-for-all/)
+# Applies a patch (`patches/boring-pq.patch`) to the boringSSL source code that
+# enables support for PQ key exchange. This feature is necessary in order to
+# compile the bindings for the default branch of boringSSL (`deps/boringssl`).
+# Alternatively, a version of boringSSL that implements the same feature set
+# can be provided by setting `BORING_BSSL_SOURCE_PATH`.
 pq-experimental = []
 
 # Disables git patching of the BoringSSL sources for features like `rpk` and `pq-experimental`, but

--- a/boring/Cargo.toml
+++ b/boring/Cargo.toml
@@ -16,6 +16,8 @@ features = ["rpk", "pq-experimental"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
+# Controlling the build
+
 # Use a FIPS-validated version of boringssl.
 fips = ["boring-sys/fips"]
 
@@ -25,16 +27,42 @@ fips-link-precompiled = ["boring-sys/fips-link-precompiled"]
 # Enables Raw public key API (https://datatracker.ietf.org/doc/html/rfc7250)
 rpk = ["boring-sys/rpk"]
 
-# Enables experimental post-quantum crypto (https://blog.cloudflare.com/post-quantum-for-all/)
+# Applies a patch to the boringSSL source code that enables support for PQ key
+# exchange. This feature is necessary in order to compile the bindings for the
+# default branch of boringSSL. Alternatively, a version of boringSSL that
+# implements the same feature set can be provided by setting
+# `BORING_BSSL_SOURCE_PATH`.
 pq-experimental = ["boring-sys/pq-experimental"]
 
 # Disables git patching of the BoringSSL sources for features like `rpk` and `pq-experimental`, but
-# keeps the related Rust API. 
-# 
-# Supposed to be used with either pre-compiled BoringSSL (via `BORING_BSSL_PATH` env variable) or 
-# with custom BoringSSL sources (via `BORING_BSSL_SOURCE_PATH` env variable) already containing 
+# keeps the related Rust API.
+#
+# Supposed to be used with either pre-compiled BoringSSL (via `BORING_BSSL_PATH` env variable) or
+# with custom BoringSSL sources (via `BORING_BSSL_SOURCE_PATH` env variable) already containing
 # required patches.
 no-patches = ["boring-sys/no-patches"]
+
+# Controlling key exchange preferences at compile time
+
+# Choose key exchange preferences at compile time. This prevents the user from
+# choosing their own preferences.
+kx-safe-default = []
+
+# Support PQ key exchange. The client will prefer classical key exchange, but
+# will upgrade to PQ key exchange if requested by the server. This is the
+# safest option if you don't know if the peer supports PQ key exchange. This
+# feature implies "kx-safe-default".
+kx-client-pq-supported = ["kx-safe-default"]
+
+# Prefer PQ key exchange. The client will prefer PQ exchange, but fallback to
+# classical key exchange if requested by the server. This is the best option if
+# you know the peer supports PQ key exchange. This feature implies
+# "kx-safe-default" and "kx-client-pq-supported".
+kx-client-pq-preferred = ["kx-safe-default", "kx-client-pq-supported"]
+
+# Disable key exchange involving non-NIST key exchange on the client side.
+# Implies "kx-safe-default".
+kx-client-nist-required = ["kx-safe-default"]
 
 [dependencies]
 bitflags = { workspace = true }

--- a/boring/src/ssl/test/mod.rs
+++ b/boring/src/ssl/test/mod.rs
@@ -1115,3 +1115,23 @@ fn session_cache_size() {
     let ctx = ctx.build();
     assert_eq!(ctx.session_cache_size(), 1234);
 }
+
+#[cfg(feature = "kx-safe-default")]
+#[test]
+fn client_set_default_curves_list() {
+    let ssl_ctx = SslContextBuilder::new(SslMethod::tls()).unwrap().build();
+    let mut ssl = Ssl::new(&ssl_ctx).unwrap();
+
+    ssl.client_set_default_curves_list()
+        .expect("Failed to set curves list. Is Kyber768 missing in boringSSL?")
+}
+
+#[cfg(feature = "kx-safe-default")]
+#[test]
+fn server_set_default_curves_list() {
+    let ssl_ctx = SslContextBuilder::new(SslMethod::tls()).unwrap().build();
+    let mut ssl = Ssl::new(&ssl_ctx).unwrap();
+
+    ssl.server_set_default_curves_list()
+        .expect("Failed to set curves list. Is Kyber768 missing in boringSSL?")
+}


### PR DESCRIPTION
Overwrite boringSSL's default key exchange preferences with safe
defaults using feature flags:

* "kx-client-pq-supported" enables support for PQ key exchange algorithms.
  Classical key exchange is still preferred, but will be upgraded to PQ
  if requested.

* "kx-client-pq-preferred" enables preference for PQ key exchange,
  with fallback to classical key exchange if requested.

* "kx-client-nist-required" disables non-FIPS-compliant algorithms on the client side.

If any of these "kx-*" features are enabled, then don't compile bindings
for `SSL_CTX_set1_curves()`. This is to prevent the feature flags from
silently overriding curve preferences chosen by the user.

Ideally we'd allow both: that is, use "kx-\*" to set defaults, but still
allow the user to manually override them. However, this doesn't work
because by the time the `SSL_CTX` is constructed, we don't yet know
whether we're the client or server. (The "kx-\*" features set different
preferences for each.)