### PR TITLE
Fix -Z minimal-versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ boring = { version = "3", path = "./boring" }
 tokio-boring = { version = "3", path = "./tokio-boring" }
 
 bindgen = { version = "0.66.1", default-features = false, features = ["runtime"] }
-cmake = "0.1"
+cmake = "0.1.18"
 fs_extra = "1.3.0"
 fslock = "0.2"
 bitflags = "1.0"


### PR DESCRIPTION
This fixes building with `cargo update -Z minimal-versions`