### PR TITLE
Re-enable ability to use pre-compiled FIPS

### DIFF
--- a/boring-sys/build.rs
+++ b/boring-sys/build.rs
@@ -602,7 +602,7 @@ fn check_feature_compatibility() {
     let is_precompiled_native_lib = env::var("BORING_BSSL_PATH").is_ok();
 
     if is_precompiled_native_lib && build_from_sources_required {
-        panic!("precompiled BoringSSL was provided, so FIPS configuration or optional patches can't be applied");
+        println!("cargo:warning=precompiled BoringSSL was provided, so FIPS configuration or optional patches can't be applied");
     }
 }
 


### PR DESCRIPTION
This check was added in https://github.com/cloudflare/boring/pull/130, and broke us. 

we currently use precompiled FIPS builds, since we don't want our developers to need to have the ancient/obscure toolchains, etc required to build FIPS boringssl.\

https://github.com/cloudflare/boring/pull/130 looks useful, but as far as I understand this only allows using FIPS boringcrypto + latest boringssl, not FIPS boringcrypto+boringssl at the same SHA. The former may be something we want to move towards in the future, but it seems nice to have both options.

I would not be surprised if I am misunderstanding #130, but there isn't much context associated with it.