### PR TITLE
Separate `fips` and `fips-link-precompiled` features.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ bindgen = { version = "0.66.1", default-features = false, features = ["runtime"]
 cmake = "0.1"
 fs_extra = "1.3.0"
 fslock = "0.2"
-bitflags = "1.0"
+bitflags = "2.4"
 foreign-types = "0.5"
 libc = "0.2"
 hex = "0.4"

--- a/boring-sys/Cargo.toml
+++ b/boring-sys/Cargo.toml
@@ -51,7 +51,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 fips = []
 
 # Link with precompiled FIPS-validated `bcm.o` module.
-fips-link-precompiled = ["fips"]
+fips-link-precompiled = []
 
 # Enables Raw public key API (https://datatracker.ietf.org/doc/html/rfc7250)
 rpk = []

--- a/boring/Cargo.toml
+++ b/boring/Cargo.toml
@@ -20,7 +20,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 fips = ["boring-sys/fips"]
 
 # Link with precompiled FIPS-validated `bcm.o` module.
-fips-link-precompiled = ["fips", "boring-sys/fips-link-precompiled"]
+fips-link-precompiled = ["boring-sys/fips-link-precompiled"]
 
 # Enables Raw public key API (https://datatracker.ietf.org/doc/html/rfc7250)
 rpk = ["boring-sys/rpk"]

--- a/boring/src/bio.rs
+++ b/boring/src/bio.rs
@@ -19,9 +19,9 @@ impl<'a> Drop for MemBioSlice<'a> {
 
 impl<'a> MemBioSlice<'a> {
     pub fn new(buf: &'a [u8]) -> Result<MemBioSlice<'a>, ErrorStack> {
-        #[cfg(not(feature = "fips"))]
+        #[cfg(not(any(feature = "fips", feature = "fips-link-precompiled")))]
         type BufLen = isize;
-        #[cfg(feature = "fips")]
+        #[cfg(any(feature = "fips", feature = "fips-link-precompiled"))]
         type BufLen = libc::c_int;
 
         ffi::init();

--- a/boring/src/fips.rs
+++ b/boring/src/fips.rs
@@ -23,8 +23,8 @@ pub fn enabled() -> bool {
 
 #[test]
 fn is_enabled() {
-    #[cfg(feature = "fips")]
+    #[cfg(any(feature = "fips", feature = "fips-link-precompiled"))]
     assert!(enabled());
-    #[cfg(not(feature = "fips"))]
+    #[cfg(not(any(feature = "fips", feature = "fips-link-precompiled")))]
     assert!(!enabled());
 }

--- a/boring/src/ssl/callbacks.rs
+++ b/boring/src/ssl/callbacks.rs
@@ -75,7 +75,7 @@ where
     // Give the callback mutable slices into which it can write the identity and psk.
     let identity_sl =
         unsafe { slice::from_raw_parts_mut(identity as *mut u8, max_identity_len as usize) };
-    let psk_sl = unsafe { slice::from_raw_parts_mut(psk as *mut u8, max_psk_len as usize) };
+    let psk_sl = unsafe { slice::from_raw_parts_mut(psk, max_psk_len as usize) };
 
     let ssl_context = ssl.ssl_context().to_owned();
     let callback = ssl_context
@@ -114,7 +114,7 @@ where
     };
 
     // Give the callback mutable slices into which it can write the psk.
-    let psk_sl = unsafe { slice::from_raw_parts_mut(psk as *mut u8, max_psk_len as usize) };
+    let psk_sl = unsafe { slice::from_raw_parts_mut(psk, max_psk_len as usize) };
 
     let ssl_context = ssl.ssl_context().to_owned();
     let callback = ssl_context
@@ -199,7 +199,7 @@ where
 {
     // SAFETY: boring provides valid inputs.
     let ssl = unsafe { SslRef::from_ptr_mut(ssl) };
-    let protos = unsafe { slice::from_raw_parts(inbuf as *const u8, inlen as usize) };
+    let protos = unsafe { slice::from_raw_parts(inbuf, inlen as usize) };
     let out = unsafe { &mut *out };
     let outlen = unsafe { &mut *outlen };
 
@@ -333,7 +333,7 @@ where
 {
     // SAFETY: boring provides valid inputs.
     let ssl = unsafe { SslRef::from_ptr_mut(ssl) };
-    let data = unsafe { slice::from_raw_parts(data as *const u8, len as usize) };
+    let data = unsafe { slice::from_raw_parts(data, len as usize) };
     let copy = unsafe { &mut *copy };
 
     let callback = ssl

--- a/boring/src/x509/mod.rs
+++ b/boring/src/x509/mod.rs
@@ -966,9 +966,9 @@ impl X509NameBuilder {
     }
 }
 
-#[cfg(not(feature = "fips"))]
+#[cfg(not(any(feature = "fips", feature = "fips-link-precompiled")))]
 type ValueLen = isize;
-#[cfg(feature = "fips")]
+#[cfg(any(feature = "fips", feature = "fips-link-precompiled"))]
 type ValueLen = i32;
 
 foreign_type_and_impl_send_sync! {
@@ -1494,7 +1494,7 @@ impl GeneralNameRef {
             let ptr = ASN1_STRING_get0_data((*self.as_ptr()).d.ia5 as *mut _);
             let len = ffi::ASN1_STRING_length((*self.as_ptr()).d.ia5 as *mut _);
 
-            let slice = slice::from_raw_parts(ptr as *const u8, len as usize);
+            let slice = slice::from_raw_parts(ptr, len as usize);
             // IA5Strings are stated to be ASCII (specifically IA5). Hopefully
             // OpenSSL checks that when loading a certificate but if not we'll
             // use this instead of from_utf8_unchecked just in case.
@@ -1527,7 +1527,7 @@ impl GeneralNameRef {
             let ptr = ASN1_STRING_get0_data((*self.as_ptr()).d.ip as *mut _);
             let len = ffi::ASN1_STRING_length((*self.as_ptr()).d.ip as *mut _);
 
-            Some(slice::from_raw_parts(ptr as *const u8, len as usize))
+            Some(slice::from_raw_parts(ptr, len as usize))
         }
     }
 }

--- a/boring/src/x509/verify.rs
+++ b/boring/src/x509/verify.rs
@@ -8,6 +8,7 @@ use crate::error::ErrorStack;
 
 bitflags! {
     /// Flags used to check an `X509` certificate.
+    #[derive(Debug, PartialEq, Eq, Clone, Copy, PartialOrd, Ord, Hash)]
     pub struct X509CheckFlags: c_uint {
         const ALWAYS_CHECK_SUBJECT = ffi::X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT as _;
         const NO_WILDCARDS = ffi::X509_CHECK_FLAG_NO_WILDCARDS as _;
@@ -37,7 +38,7 @@ impl X509VerifyParamRef {
     /// [`X509_VERIFY_PARAM_set_hostflags`]: https://www.openssl.org/docs/man1.1.0/crypto/X509_VERIFY_PARAM_set_hostflags.html
     pub fn set_hostflags(&mut self, hostflags: X509CheckFlags) {
         unsafe {
-            ffi::X509_VERIFY_PARAM_set_hostflags(self.as_ptr(), hostflags.bits);
+            ffi::X509_VERIFY_PARAM_set_hostflags(self.as_ptr(), hostflags.bits());
         }
     }
 

--- a/hyper-boring/Cargo.toml
+++ b/hyper-boring/Cargo.toml
@@ -23,7 +23,7 @@ runtime = ["hyper/runtime"]
 fips = ["tokio-boring/fips"]
 
 # Link with precompiled FIPS-validated `bcm.o` module.
-fips-link-precompiled = ["fips", "tokio-boring/fips-link-precompiled"]
+fips-link-precompiled = ["tokio-boring/fips-link-precompiled"]
 
 # Enables Raw public key API (https://datatracker.ietf.org/doc/html/rfc7250)
 rpk = ["tokio-boring/rpk"]

--- a/tokio-boring/Cargo.toml
+++ b/tokio-boring/Cargo.toml
@@ -20,7 +20,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 fips = ["boring/fips", "boring-sys/fips"]
 
 # Link with precompiled FIPS-validated `bcm.o` module.
-fips-link-precompiled = ["fips", "boring/fips-link-precompiled", "boring-sys/fips-link-precompiled"]
+fips-link-precompiled = ["boring/fips-link-precompiled", "boring-sys/fips-link-precompiled"]
 
 # Enables Raw public key API (https://datatracker.ietf.org/doc/html/rfc7250)
 rpk = ["boring/rpk"]


### PR DESCRIPTION
Make the later compatible with `rpk` feature.