### PR TITLE
Tweaks for ergonomic linking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "3.0.5"
+version = "3.1.0"
 repository = "https://github.com/cloudflare/boring"
 edition = "2021"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "3.0.4"
+version = "3.0.5"
 repository = "https://github.com/cloudflare/boring"
 edition = "2021"
 

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,5 +1,5 @@
 3.1.0
-- 2023-09-12 Release 3.0.5
+- 2023-09-12 Release 3.1.0
 - 2023-09-12 tweaks for ergonomic linking
 - 2023-08-08 Use features to set key exchange preferences
 - 2023-08-30 Introduce `no-patches` feature

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,4 +1,4 @@
-3.0.5
+3.1.0
 - 2023-09-12 Release 3.0.5
 - 2023-09-12 tweaks for ergonomic linking
 - 2023-08-08 Use features to set key exchange preferences

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,4 +1,19 @@
+3.0.5
+- 2023-09-12 Release 3.0.5
+- 2023-09-12 tweaks for ergonomic linking
+- 2023-08-08 Use features to set key exchange preferences
+- 2023-08-30 Introduce `no-patches` feature
+- 2023-08-29 run `publish --dry-run` instead of `pacakge` on CI
+- 2023-08-29 fix missing space in cargo package CI command
+- 2023-08-25 ci: run the cargo package check for all targets
+- 2023-08-25 boring-sys: include all files needed to build FIPS
+- 2023-08-25 add CI jobs to run `cargo package`
+- 2023-08-15 Fix -Z minimal-versions
+- 2023-08-29 Separate `fips` and `fips-link-precompiled` features.
+- 2023-08-05 Bump version in Cargo.toml
+
 3.0.4
+- 2023-08-05 Release 3.0.4
 - 2023-08-05 Add missing cmake files to the package
 
 3.0.3
@@ -21,8 +36,6 @@
 3.0.0
 - 2023-07-29 Fix publishing
 - 2023-07-28 Merge pull request #131 from inikulin/rel-3.0.0
-
-.3.0.0
 - 2023-07-28 Release 3.0.0
 - 2023-07-28 Add git-cliff configuration
 - 2023-07-28 Merge pull request #84 from signalapp/macos-cross-compile

--- a/boring-sys/build.rs
+++ b/boring-sys/build.rs
@@ -627,6 +627,10 @@ fn main() {
             "cargo:rustc-link-search=native={}/build/ssl/{}",
             bssl_dir, build_path
         );
+        println!(
+            "cargo:rustc-link-search=native={}/lib/{}",
+            bssl_dir, build_path
+        );
     } else {
         println!(
             "cargo:rustc-link-search=native={}/build/{}",
@@ -642,6 +646,10 @@ fn main() {
     println!("cargo:rustc-link-lib=static=ssl");
 
     let include_path = env::var("BORING_BSSL_INCLUDE_PATH").unwrap_or_else(|_| {
+        if let Ok(bssl_path) = env::var("BORING_BSSL_PATH") {
+            return format!("{}/include", bssl_path);
+        }
+
         let src_path = get_boringssl_source_path();
 
         if Path::new(&src_path).join("include").exists() {


### PR DESCRIPTION
This PR is intended to make linking against a pre-compiled, FIPS-validated version of BoringSSL a bit easier and cleaner. It adds a subdir to Cargo's rustc-link-native directories and automatically sets BoringSSL's include path to `${BORING_BSSL_PATH}/include` if `BORING_BSSL_PATH` is set and `BORING_BSSL_INCLUDE_PATH` is not set.