### PR TITLE
Enable P-521 with "kx-safe-default"

### DIFF
--- a/boring/src/ssl/mod.rs
+++ b/boring/src/ssl/mod.rs
@@ -2423,21 +2423,21 @@ impl SslRef {
     fn client_set_default_curves_list(&mut self) -> Result<(), ErrorStack> {
         let curves = if cfg!(feature = "kx-client-pq-preferred") {
             if cfg!(feature = "kx-client-nist-required") {
-                "P256Kyber768Draft00:P-256:P-384"
+                "P256Kyber768Draft00:P-256:P-384:P-521"
             } else {
-                "X25519Kyber768Draft00:X25519:P256Kyber768Draft00:P-256:P-384"
+                "X25519Kyber768Draft00:X25519:P256Kyber768Draft00:P-256:P-384:P-521"
             }
         } else if cfg!(feature = "kx-client-pq-supported") {
             if cfg!(feature = "kx-client-nist-required") {
-                "P-256:P-384:P256Kyber768Draft00"
+                "P-256:P-384:P-521:P256Kyber768Draft00"
             } else {
-                "X25519:P-256:P-384:X25519Kyber768Draft00:P256Kyber768Draft00"
+                "X25519:P-256:P-384:P-521:X25519Kyber768Draft00:P256Kyber768Draft00"
             }
         } else {
             if cfg!(feature = "kx-client-nist-required") {
-                "P-256:P-384"
+                "P-256:P-384:P-521"
             } else {
-                "X25519:P-256:P-384"
+                "X25519:P-256:P-384:P-521"
             }
         };
 


### PR DESCRIPTION
While not commonly used, P-521 is a perfectly safe choice of key exchange algorithm.