### PR TITLE
Remove boring::fips::enable (fixes #150)

### DIFF
--- a/boring/src/fips.rs
+++ b/boring/src/fips.rs
@@ -3,16 +3,7 @@
 //! See [OpenSSL's documentation] for details.
 //!
 //! [OpenSSL's documentation]: https://www.openssl.org/docs/fips/UserGuide-2.0.pdf
-use crate::cvt;
-use crate::error::ErrorStack;
 use crate::ffi;
-
-/// Moves the library into or out of the FIPS 140-2 mode of operation.
-///
-/// This corresponds to `FIPS_mode_set`.
-pub fn enable(enabled: bool) -> Result<(), ErrorStack> {
-    unsafe { cvt(ffi::FIPS_mode_set(enabled as _)).map(|_| ()) }
-}
 
 /// Determines if the library is running in the FIPS 140-2 mode of operation.
 ///


### PR DESCRIPTION
In boringssl, FIPS_mode_set is more or less useless, and it doesn't even set an error stack at all on failure, so there is no point using it instead of FIPS_mode.