### PR TITLE
Introduce a new set of env variables specific to FIPS builds

### DIFF
--- a/boring-sys/Cargo.toml
+++ b/boring-sys/Cargo.toml
@@ -68,15 +68,15 @@ rpk = []
 # enables support for PQ key exchange. This feature is necessary in order to
 # compile the bindings for the default branch of boringSSL (`deps/boringssl`).
 # Alternatively, a version of boringSSL that implements the same feature set
-# can be provided by setting `BORING_BSSL_SOURCE_PATH`.
+# can be provided by setting `BORING_BSSL{,_FIPS}_SOURCE_PATH`.
 pq-experimental = []
 
-# Disables git patching of the BoringSSL sources for features like `rpk` and `pq-experimental`, but
-# keeps the related Rust API. 
+# Disables git patching of the BoringSSL sources for features like `rpk` and `pq-experimental`,
+# but keeps the related Rust API.
 # 
-# Supposed to be used with either pre-compiled BoringSSL (via `BORING_BSSL_PATH` env variable) or 
-# with custom BoringSSL sources (via `BORING_BSSL_SOURCE_PATH` env variable) already containing 
-# required patches.
+# Supposed to be used with either pre-compiled BoringSSL (via `BORING_BSSL{,_FIPS}_PATH` env
+# variable) or  with custom BoringSSL sources (via `BORING_BSSL{,_FIPS}_SOURCE_PATH` env variable)
+# already containing required patches.
 no-patches = []
 
 [build-dependencies]

--- a/boring-sys/Cargo.toml
+++ b/boring-sys/Cargo.toml
@@ -9,6 +9,7 @@ description = "FFI bindings to BoringSSL"
 repository = { workspace = true }
 documentation = "https://docs.rs/boring-sys"
 links = "boringssl"
+build = "build/main.rs"
 readme = "README.md"
 categories = ["cryptography", "external-ffi-bindings"]
 edition = { workspace = true }
@@ -44,7 +45,7 @@ include = [
     "/deps/boringssl-fips/**/CMakeLists.txt",
     "/deps/boringssl-fips/**/sources.cmake",
     "/deps/boringssl-fips/LICENSE",
-    "/build.rs",
+    "/build/*",
     "/src",
     "/patches",
 ]

--- a/boring-sys/build/config.rs
+++ b/boring-sys/build/config.rs
@@ -27,8 +27,6 @@ pub(crate) struct Env {
     pub(crate) include_path: Option<PathBuf>,
     pub(crate) source_path: Option<PathBuf>,
     pub(crate) precompiled_bcm_o: Option<PathBuf>,
-    #[allow(dead_code)]
-    pub(crate) build_dir: Option<PathBuf>,
     pub(crate) debug: Option<OsString>,
     pub(crate) opt_level: Option<OsString>,
     pub(crate) android_ndk_home: Option<PathBuf>,
@@ -115,7 +113,6 @@ impl Env {
             include_path: var("BORING_BSSL_INCLUDE_PATH").map(Into::into),
             source_path: var("BORING_BSSL_SOURCE_PATH").map(Into::into),
             precompiled_bcm_o: var("BORING_SSL_PRECOMPILED_BCM_O").map(Into::into),
-            build_dir: var("BORINGSSL_BUILD_DIR").map(Into::into),
             debug: var("DEBUG"),
             opt_level: var("OPT_LEVEL"),
             android_ndk_home: var("ANDROID_NDK_HOME").map(Into::into),

--- a/boring-sys/build/config.rs
+++ b/boring-sys/build/config.rs
@@ -1,0 +1,135 @@
+use std::env;
+use std::ffi::OsString;
+use std::path::PathBuf;
+
+pub(crate) struct Config {
+    // TODO(nox): Use manifest dir instead.
+    pub(crate) pwd: PathBuf,
+    pub(crate) manifest_dir: PathBuf,
+    pub(crate) out_dir: PathBuf,
+    pub(crate) host: String,
+    pub(crate) target: String,
+    pub(crate) target_arch: String,
+    pub(crate) target_env: String,
+    pub(crate) target_os: String,
+    pub(crate) features: Features,
+    pub(crate) env: Env,
+}
+
+pub(crate) struct Features {
+    pub(crate) no_patches: bool,
+    pub(crate) fips: bool,
+    pub(crate) fips_link_precompiled: bool,
+    pub(crate) pq_experimental: bool,
+    pub(crate) rpk: bool,
+}
+
+pub(crate) struct Env {
+    pub(crate) path: Option<PathBuf>,
+    pub(crate) include_path: Option<PathBuf>,
+    pub(crate) source_path: Option<PathBuf>,
+    pub(crate) precompiled_bcm_o: Option<PathBuf>,
+    #[allow(dead_code)]
+    pub(crate) build_dir: Option<PathBuf>,
+    pub(crate) debug: Option<OsString>,
+    pub(crate) opt_level: Option<OsString>,
+    pub(crate) android_ndk_home: Option<PathBuf>,
+}
+
+impl Config {
+    pub(crate) fn from_env() -> Self {
+        let pwd = env::current_dir().unwrap();
+
+        let manifest_dir = env::var_os("CARGO_MANIFEST_DIR").unwrap().into();
+        let out_dir = env::var_os("OUT_DIR").unwrap().into();
+        let host = env::var("HOST").unwrap();
+        let target = env::var("TARGET").unwrap();
+        let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+        let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap();
+        let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+
+        let features = Features::from_env();
+        let env = Env::from_env();
+
+        let config = Self {
+            pwd,
+            manifest_dir,
+            out_dir,
+            host,
+            target,
+            target_arch,
+            target_env,
+            target_os,
+            features,
+            env,
+        };
+
+        config.check_feature_compatibility();
+
+        config
+    }
+
+    fn check_feature_compatibility(&self) {
+        if self.features.fips && self.features.rpk {
+            panic!("`fips` and `rpk` features are mutually exclusive");
+        }
+
+        let is_precompiled_native_lib = self.env.path.is_some();
+        let is_external_native_lib_source =
+            !is_precompiled_native_lib && self.env.source_path.is_none();
+
+        if self.features.no_patches && is_external_native_lib_source {
+            panic!(
+                "`no-patches` feature is supposed to be used with `BORING_BSSL_PATH`\
+                or `BORING_BSSL_SOURCE_PATH` env variables"
+            );
+        }
+
+        let features_with_patches_enabled = self.features.rpk || self.features.pq_experimental;
+        let patches_required = features_with_patches_enabled && !self.features.no_patches;
+        let build_from_sources_required = self.features.fips_link_precompiled || patches_required;
+
+        if is_precompiled_native_lib && build_from_sources_required {
+            panic!("precompiled BoringSSL was provided, so FIPS configuration or optional patches can't be applied");
+        }
+    }
+}
+
+impl Features {
+    fn from_env() -> Self {
+        let no_patches = env::var_os("CARGO_FEATURE_NO_PATCHES").is_some();
+        let fips = env::var_os("CARGO_FEATURE_FIPS").is_some();
+        let fips_link_precompiled = env::var_os("CARGO_FEATURE_FIPS_LINK_PRECOMPILED").is_some();
+        let pq_experimental = env::var_os("CARGO_FEATURE_PQ_EXPERIMENTAL").is_some();
+        let rpk = env::var_os("CARGO_FEATURE_RPK").is_some();
+
+        Self {
+            no_patches,
+            fips,
+            fips_link_precompiled,
+            pq_experimental,
+            rpk,
+        }
+    }
+}
+
+impl Env {
+    fn from_env() -> Self {
+        Self {
+            path: var("BORING_BSSL_PATH").map(Into::into),
+            include_path: var("BORING_BSSL_INCLUDE_PATH").map(Into::into),
+            source_path: var("BORING_BSSL_SOURCE_PATH").map(Into::into),
+            precompiled_bcm_o: var("BORING_SSL_PRECOMPILED_BCM_O").map(Into::into),
+            build_dir: var("BORINGSSL_BUILD_DIR").map(Into::into),
+            debug: var("DEBUG"),
+            opt_level: var("OPT_LEVEL"),
+            android_ndk_home: var("ANDROID_NDK_HOME").map(Into::into),
+        }
+    }
+}
+
+fn var(name: &str) -> Option<OsString> {
+    println!("cargo:rerun-if-env-changed={name}");
+
+    env::var_os(name)
+}

--- a/boring-sys/build/config.rs
+++ b/boring-sys/build/config.rs
@@ -112,7 +112,7 @@ impl Env {
             path: var("BORING_BSSL_PATH").map(Into::into),
             include_path: var("BORING_BSSL_INCLUDE_PATH").map(Into::into),
             source_path: var("BORING_BSSL_SOURCE_PATH").map(Into::into),
-            precompiled_bcm_o: var("BORING_SSL_PRECOMPILED_BCM_O").map(Into::into),
+            precompiled_bcm_o: var("BORING_BSSL_PRECOMPILED_BCM_O").map(Into::into),
             debug: var("DEBUG"),
             opt_level: var("OPT_LEVEL"),
             android_ndk_home: var("ANDROID_NDK_HOME").map(Into::into),

--- a/boring-sys/build/config.rs
+++ b/boring-sys/build/config.rs
@@ -3,8 +3,6 @@ use std::ffi::OsString;
 use std::path::PathBuf;
 
 pub(crate) struct Config {
-    // TODO(nox): Use manifest dir instead.
-    pub(crate) pwd: PathBuf,
     pub(crate) manifest_dir: PathBuf,
     pub(crate) out_dir: PathBuf,
     pub(crate) host: String,
@@ -38,8 +36,6 @@ pub(crate) struct Env {
 
 impl Config {
     pub(crate) fn from_env() -> Self {
-        let pwd = env::current_dir().unwrap();
-
         let manifest_dir = env::var_os("CARGO_MANIFEST_DIR").unwrap().into();
         let out_dir = env::var_os("OUT_DIR").unwrap().into();
         let host = env::var("HOST").unwrap();
@@ -52,7 +48,6 @@ impl Config {
         let env = Env::from_env();
 
         let config = Self {
-            pwd,
             manifest_dir,
             out_dir,
             host,

--- a/boring-sys/build/main.rs
+++ b/boring-sys/build/main.rs
@@ -529,7 +529,7 @@ fn link_in_precompiled_bcm_o(config: &Config) {
 
     let bssl_dir = built_boring_source_path(config);
     let bcm_o_src_path = config.env.precompiled_bcm_o.as_ref()
-        .expect("`fips-link-precompiled` requires `BORING_SSL_PRECOMPILED_BCM_O` env variable to be specified");
+        .expect("`fips-link-precompiled` requires `BORING_BSSL_PRECOMPILED_BCM_O` env variable to be specified");
 
     let libcrypto_path = bssl_dir
         .join("build/crypto/libcrypto.a")

--- a/boring-sys/build/main.rs
+++ b/boring-sys/build/main.rs
@@ -529,7 +529,7 @@ fn link_in_precompiled_bcm_o(config: &Config) {
 
     let bssl_dir = built_boring_source_path(config);
     let bcm_o_src_path = config.env.precompiled_bcm_o.as_ref()
-        .expect("`fips-link-precompiled` requires `BORING_BSSL_PRECOMPILED_BCM_O` env variable to be specified");
+        .expect("`fips-link-precompiled` requires `BORING_BSSL_FIPS_PRECOMPILED_BCM_O` env variable to be specified");
 
     let libcrypto_path = bssl_dir
         .join("build/crypto/libcrypto.a")

--- a/boring-sys/build/main.rs
+++ b/boring-sys/build/main.rs
@@ -249,8 +249,10 @@ fn get_boringssl_cmake_config(config: &Config) -> cmake::Config {
                 "x86" => {
                     boringssl_cmake.define(
                         "CMAKE_TOOLCHAIN_FILE",
+                        // `src_path` can be a path relative to the manifest dir, but
+                        // cmake hates that.
                         config
-                            .pwd
+                            .manifest_dir
                             .join(src_path)
                             .join("src/util/32-bit-toolchain.cmake")
                             .as_os_str(),
@@ -259,13 +261,19 @@ fn get_boringssl_cmake_config(config: &Config) -> cmake::Config {
                 "aarch64" => {
                     boringssl_cmake.define(
                         "CMAKE_TOOLCHAIN_FILE",
-                        config.pwd.join("cmake/aarch64-linux.cmake").as_os_str(),
+                        config
+                            .manifest_dir
+                            .join("cmake/aarch64-linux.cmake")
+                            .as_os_str(),
                     );
                 }
                 "arm" => {
                     boringssl_cmake.define(
                         "CMAKE_TOOLCHAIN_FILE",
-                        config.pwd.join("cmake/armv7-linux.cmake").as_os_str(),
+                        config
+                            .manifest_dir
+                            .join("cmake/armv7-linux.cmake")
+                            .as_os_str(),
                     );
                 }
                 _ => {

--- a/boring/Cargo.toml
+++ b/boring/Cargo.toml
@@ -31,15 +31,15 @@ rpk = ["boring-sys/rpk"]
 # exchange. This feature is necessary in order to compile the bindings for the
 # default branch of boringSSL. Alternatively, a version of boringSSL that
 # implements the same feature set can be provided by setting
-# `BORING_BSSL_SOURCE_PATH`.
+# `BORING_BSSL{,_FIPS}_SOURCE_PATH`.
 pq-experimental = ["boring-sys/pq-experimental"]
 
-# Disables git patching of the BoringSSL sources for features like `rpk` and `pq-experimental`, but
-# keeps the related Rust API.
+# Disables git patching of the BoringSSL sources for features like `rpk` and `pq-experimental`,
+# but keeps the related Rust API.
 #
-# Supposed to be used with either pre-compiled BoringSSL (via `BORING_BSSL_PATH` env variable) or
-# with custom BoringSSL sources (via `BORING_BSSL_SOURCE_PATH` env variable) already containing
-# required patches.
+# Supposed to be used with either pre-compiled BoringSSL (via `BORING_BSSL{,_FIPS}_PATH` env
+# variable) or with custom BoringSSL sources (via `BORING_BSSL{,_FIPS}_SOURCE_PATH` env variable)
+# already containing required patches.
 no-patches = ["boring-sys/no-patches"]
 
 # Controlling key exchange preferences at compile time

--- a/boring/src/lib.rs
+++ b/boring/src/lib.rs
@@ -46,7 +46,7 @@
 //! ## Linking current BoringSSL version with precompiled FIPS-validated module (`bcm.o`)
 //! It's possible to link latest supported version of BoringSSL with FIPS-validated crypto module
 //! (`bcm.o`). To enable this compilation option one should enable `fips-link-precompiled`
-//! compilation feature and provide a `BORING_SSL_PRECOMPILED_BCM_O` env variable with a path to the
+//! compilation feature and provide a `BORING_BSSL_PRECOMPILED_BCM_O` env variable with a path to the
 //! precompiled FIPS-validated `bcm.o` module.
 //!
 //! # Optional patches

--- a/boring/src/lib.rs
+++ b/boring/src/lib.rs
@@ -18,18 +18,26 @@
 //!
 //! # Compilation and linking options
 //!
+//! ## Environment variables
+//!
+//! This crate uses various environment variables to tweak how boring is built. The variables
+//! are all prefixed by `BORING_BSSL_` for non-FIPS builds, and by `BORING_BSSL_FIPS_` for FIPS builds.
+//!
 //! ## Support for pre-built binaries or custom source
 //!
 //! While this crate can build BoringSSL on its own, you may want to provide pre-built binaries instead.
-//! To do so, specify the environment variable `BORING_BSSL_PATH` with the path to the binaries.
+//! To do so, specify the environment variable `BORING_BSSL{,_FIPS}_PATH` with the path to the binaries.
 //!
-//! You can also provide specific headers by setting `BORING_BSSL_INCLUDE_PATH`.
+//! You can also provide specific headers by setting `BORING_BSSL{,_FIPS}_INCLUDE_PATH`.
 //!
-//! _Notes_: The crate will look for headers in the `$BORING_BSSL_INCLUDE_PATH/openssl/` folder, make sure to place your headers there.
+//! _Notes_: The crate will look for headers in the`$BORING_BSSL{,_FIPS}_INCLUDE_PATH/openssl/`
+//! folder, make sure to place your headers there.
 //!
-//! In alternative a different path for the BoringSSL source code directory can be specified by setting `BORING_BSSL_SOURCE_PATH` which will automatically be compiled during the build process.
+//! In alternative a different path for the BoringSSL source code directory can be specified by setting
+//! `BORING_BSSL{,_FIPS}_SOURCE_PATH` which will automatically be compiled during the build process.
 //!
-//! _Warning_: When providing a different version of BoringSSL make sure to use a compatible one, the crate relies on the presence of certain functions.
+//! _Warning_: When providing a different version of BoringSSL make sure to use a compatible one, the
+//! crate relies on the presence of certain functions.
 //!
 //! ## Building with a FIPS-validated module
 //!
@@ -44,10 +52,14 @@
 //! ```
 //!
 //! ## Linking current BoringSSL version with precompiled FIPS-validated module (`bcm.o`)
+//!
 //! It's possible to link latest supported version of BoringSSL with FIPS-validated crypto module
 //! (`bcm.o`). To enable this compilation option one should enable `fips-link-precompiled`
-//! compilation feature and provide a `BORING_BSSL_PRECOMPILED_BCM_O` env variable with a path to the
+//! compilation feature and provide a `BORING_BSSL_FIPS_PRECOMPILED_BCM_O` env variable with a path to the
 //! precompiled FIPS-validated `bcm.o` module.
+//!
+//! Note that `BORING_BSSL_PRECOMPILED_BCM_O` is never used, as linking BoringSSL with precompiled non-FIPS
+//! module is not supported.
 //!
 //! # Optional patches
 //!

--- a/hyper-boring/Cargo.toml
+++ b/hyper-boring/Cargo.toml
@@ -31,12 +31,12 @@ rpk = ["tokio-boring/rpk"]
 # Enables experimental post-quantum crypto (https://blog.cloudflare.com/post-quantum-for-all/)
 pq-experimental = ["tokio-boring/pq-experimental"]
 
-# Disables git patching of the BoringSSL sources for features like `rpk` and `pq-experimental`, but
-# keeps the related Rust API. 
+# Disables git patching of the BoringSSL sources for features like `rpk` and `pq-experimental`,
+# but keeps the related Rust API.
 # 
-# Supposed to be used with either pre-compiled BoringSSL (via `BORING_BSSL_PATH` env variable) or 
-# with custom BoringSSL sources (via `BORING_BSSL_SOURCE_PATH` env variable) already containing 
-# required patches.
+# Supposed to be used with either pre-compiled BoringSSL (via `BORING_BSSL{,_FIPS}_PATH` env
+# variable) or with custom BoringSSL sources (via `BORING_BSSL{,_FIPS}_SOURCE_PATH` env variable)
+# already containing required patches.
 no-patches = ["tokio-boring/no-patches"]
 
 

--- a/tokio-boring/Cargo.toml
+++ b/tokio-boring/Cargo.toml
@@ -28,12 +28,12 @@ rpk = ["boring/rpk"]
 # Enables experimental post-quantum crypto (https://blog.cloudflare.com/post-quantum-for-all/)
 pq-experimental = ["boring/pq-experimental"]
 
-# Disables git patching of the BoringSSL sources for features like `rpk` and `pq-experimental`, but
-# keeps the related Rust API. 
+# Disables git patching of the BoringSSL sources for features like `rpk` and `pq-experimental`,
+# but keeps the related Rust API.
 # 
-# Supposed to be used with either pre-compiled BoringSSL (via `BORING_BSSL_PATH` env variable) or 
-# with custom BoringSSL sources (via `BORING_BSSL_SOURCE_PATH` env variable) already containing 
-# required patches.
+# Supposed to be used with either pre-compiled BoringSSL (via `BORING_BSSL{,_FIPS}_PATH` env
+# variable) or  with custom BoringSSL sources (via `BORING_BSSL{,_FIPS}_SOURCE_PATH` env variable)
+# already containing required patches.
 no-patches = ["boring/no-patches"]
 
 [dependencies]


### PR DESCRIPTION
BoringSSL checkouts for FIPS-validated builds and for normal builds can be quite different, enough for them to not build with their expected `fips` or `fips-link-precompiled` feature settings, for example when they are both used as runtime dependencies and build dependencies. When using cargo's resolver 2, the user then needs to make sure that boring is compiled with the same FIPS-related features for both kind of dependencies, which can sometimes be difficult.

For this reason, this PR introduces a new set of variables prefixed by `BORING_BSSL_FIPS_` instead of `BORING_BSSL_`:

* `BORING_BSSL_FIPS_PATH`
* `BORING_BSSL_FIPS_INCLUDE_PATH`
* `BORING_BSSL_FIPS_SOURCE_PATH`
* `BORING_BSSL_FIPS_PRECOMPILED_BCM_O`

While at it, the prefix were normalized, as `BORING_BSSL_FIPS_PRECOMPILED_BCM_O` used to be `BORING_SSL_PRECOMPILED_BCM_O` (note how it was prefixed with `BORING_SSL_` instead of `BORING_BSSL_`).

To support this work, the build script was refactored and a helper struct `Config` was introduced to help navigating how the env variables and the various feature flags were used. Now they are all struct fields that can be tracked easily with rust-analyzer.