### PR TITLE
Rework rpk and no-patches features

### DIFF
--- a/boring-sys/Cargo.toml
+++ b/boring-sys/Cargo.toml
@@ -71,14 +71,6 @@ rpk = []
 # can be provided by setting `BORING_BSSL{,_FIPS}_SOURCE_PATH`.
 pq-experimental = []
 
-# Disables git patching of the BoringSSL sources for features like `rpk` and `pq-experimental`,
-# but keeps the related Rust API.
-# 
-# Supposed to be used with either pre-compiled BoringSSL (via `BORING_BSSL{,_FIPS}_PATH` env
-# variable) or  with custom BoringSSL sources (via `BORING_BSSL{,_FIPS}_SOURCE_PATH` env variable)
-# already containing required patches.
-no-patches = []
-
 [build-dependencies]
 bindgen = { workspace = true }
 cmake = { workspace = true }

--- a/boring-sys/build/main.rs
+++ b/boring-sys/build/main.rs
@@ -496,7 +496,7 @@ fn built_boring_source_path(config: &Config) -> &PathBuf {
     static BUILD_SOURCE_PATH: OnceLock<PathBuf> = OnceLock::new();
 
     BUILD_SOURCE_PATH.get_or_init(|| {
-        if config.features.no_patches {
+        if config.env.assume_patched {
             println!(
                 "cargo:warning=skipping git patches application, provided\
                 native BoringSSL is expected to have the patches included"

--- a/boring/Cargo.toml
+++ b/boring/Cargo.toml
@@ -25,22 +25,18 @@ fips = ["boring-sys/fips"]
 fips-link-precompiled = ["boring-sys/fips-link-precompiled"]
 
 # Enables Raw public key API (https://datatracker.ietf.org/doc/html/rfc7250)
+# This feature is necessary in order to compile the bindings for the
+# default branch of boringSSL. Alternatively, a version of boringSSL that
+# implements the same feature set can be provided by setting
+# `BORING_BSSL{,_FIPS}_SOURCE_PATH` and `BORING_BSSL{,_FIPS}_ASSUME_PATCHED`.
 rpk = ["boring-sys/rpk"]
 
 # Applies a patch to the boringSSL source code that enables support for PQ key
 # exchange. This feature is necessary in order to compile the bindings for the
 # default branch of boringSSL. Alternatively, a version of boringSSL that
 # implements the same feature set can be provided by setting
-# `BORING_BSSL{,_FIPS}_SOURCE_PATH`.
+# `BORING_BSSL{,_FIPS}_SOURCE_PATH` and `BORING_BSSL{,_FIPS}_ASSUME_PATCHED`.
 pq-experimental = ["boring-sys/pq-experimental"]
-
-# Disables git patching of the BoringSSL sources for features like `rpk` and `pq-experimental`,
-# but keeps the related Rust API.
-#
-# Supposed to be used with either pre-compiled BoringSSL (via `BORING_BSSL{,_FIPS}_PATH` env
-# variable) or with custom BoringSSL sources (via `BORING_BSSL{,_FIPS}_SOURCE_PATH` env variable)
-# already containing required patches.
-no-patches = ["boring-sys/no-patches"]
 
 # Controlling key exchange preferences at compile time
 

--- a/hyper-boring/Cargo.toml
+++ b/hyper-boring/Cargo.toml
@@ -25,9 +25,6 @@ fips = ["tokio-boring/fips"]
 # Link with precompiled FIPS-validated `bcm.o` module.
 fips-link-precompiled = ["tokio-boring/fips-link-precompiled"]
 
-# Enables Raw public key API (https://datatracker.ietf.org/doc/html/rfc7250)
-rpk = ["tokio-boring/rpk"]
-
 # Enables experimental post-quantum crypto (https://blog.cloudflare.com/post-quantum-for-all/)
 pq-experimental = ["tokio-boring/pq-experimental"]
 
@@ -38,7 +35,6 @@ pq-experimental = ["tokio-boring/pq-experimental"]
 # variable) or with custom BoringSSL sources (via `BORING_BSSL{,_FIPS}_SOURCE_PATH` env variable)
 # already containing required patches.
 no-patches = ["tokio-boring/no-patches"]
-
 
 [dependencies]
 antidote = { workspace = true }

--- a/hyper-boring/Cargo.toml
+++ b/hyper-boring/Cargo.toml
@@ -28,14 +28,6 @@ fips-link-precompiled = ["tokio-boring/fips-link-precompiled"]
 # Enables experimental post-quantum crypto (https://blog.cloudflare.com/post-quantum-for-all/)
 pq-experimental = ["tokio-boring/pq-experimental"]
 
-# Disables git patching of the BoringSSL sources for features like `rpk` and `pq-experimental`,
-# but keeps the related Rust API.
-# 
-# Supposed to be used with either pre-compiled BoringSSL (via `BORING_BSSL{,_FIPS}_PATH` env
-# variable) or with custom BoringSSL sources (via `BORING_BSSL{,_FIPS}_SOURCE_PATH` env variable)
-# already containing required patches.
-no-patches = ["tokio-boring/no-patches"]
-
 [dependencies]
 antidote = { workspace = true }
 http = { workspace = true }

--- a/tokio-boring/Cargo.toml
+++ b/tokio-boring/Cargo.toml
@@ -25,14 +25,6 @@ fips-link-precompiled = ["boring/fips-link-precompiled", "boring-sys/fips-link-p
 # Enables experimental post-quantum crypto (https://blog.cloudflare.com/post-quantum-for-all/)
 pq-experimental = ["boring/pq-experimental"]
 
-# Disables git patching of the BoringSSL sources for features like `rpk` and `pq-experimental`,
-# but keeps the related Rust API.
-# 
-# Supposed to be used with either pre-compiled BoringSSL (via `BORING_BSSL{,_FIPS}_PATH` env
-# variable) or  with custom BoringSSL sources (via `BORING_BSSL{,_FIPS}_SOURCE_PATH` env variable)
-# already containing required patches.
-no-patches = ["boring/no-patches"]
-
 [dependencies]
 boring = { workspace = true }
 boring-sys = { workspace = true }

--- a/tokio-boring/Cargo.toml
+++ b/tokio-boring/Cargo.toml
@@ -22,9 +22,6 @@ fips = ["boring/fips", "boring-sys/fips"]
 # Link with precompiled FIPS-validated `bcm.o` module.
 fips-link-precompiled = ["boring/fips-link-precompiled", "boring-sys/fips-link-precompiled"]
 
-# Enables Raw public key API (https://datatracker.ietf.org/doc/html/rfc7250)
-rpk = ["boring/rpk"]
-
 # Enables experimental post-quantum crypto (https://blog.cloudflare.com/post-quantum-for-all/)
 pq-experimental = ["boring/pq-experimental"]
 


### PR DESCRIPTION
This removes `rpk` from tokio-boring and hyper-boring, and replaces feature `no-patches` with env variable `BORING_BSSL{,_FIPS}_ASSUME_PATCHED`, see individual commits for rationale.