### PR TITLE
hyper and tokio "full" feature for dev builds only

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,11 +27,11 @@ libc = "0.2"
 hex = "0.4"
 rusty-hook = "^0.11"
 futures = "0.3"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1" }
 anyhow = "1"
 antidote = "1.0.0"
 http = "0.2"
-hyper = { version = "0.14", default-features = false, features = ["full"] }
+hyper = { version = "0.14", default-features = false }
 linked_hash_set = "0.1"
 once_cell = "1.0"
 tower-layer = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ libc = "0.2"
 hex = "0.4"
 rusty-hook = "^0.11"
 futures = "0.3"
-tokio = { version = "1" }
+tokio = "1"
 anyhow = "1"
 antidote = "1.0.0"
 http = "0.2"

--- a/hyper-boring/Cargo.toml
+++ b/hyper-boring/Cargo.toml
@@ -40,6 +40,6 @@ tokio-boring = { workspace = true }
 tower-layer = { workspace = true }
 
 [dev-dependencies]
-hyper = { workspace = true }
-tokio = { workspace = true }
+hyper = { workspace = true, features = [ "full" ] }
+tokio = { workspace = true, features = [ "full" ] }
 futures = { workspace = true }

--- a/tokio-boring/Cargo.toml
+++ b/tokio-boring/Cargo.toml
@@ -33,5 +33,5 @@ tokio = { workspace = true }
 
 [dev-dependencies]
 futures = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = [ "full" ] }
 anyhow = { workspace = true }


### PR DESCRIPTION
This was an accidental regression in
d1ee9bfd868a472a04f92e15e011d0fc42db6b88 which leads to pulling in the full featureset of tokio and hyper for all dependents of tokio-boring and hyper-boring.

Fixes #179.