### PR TITLE
Remove Sync trait bounds on callback futures

### DIFF
--- a/tokio-boring/src/lib.rs
+++ b/tokio-boring/src/lib.rs
@@ -29,6 +29,7 @@ use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 mod async_callbacks;
 mod bridge;
+mod mut_only;
 
 use self::async_callbacks::TASK_WAKER_INDEX;
 pub use self::async_callbacks::{

--- a/tokio-boring/src/mut_only.rs
+++ b/tokio-boring/src/mut_only.rs
@@ -1,0 +1,14 @@
+pub(crate) struct MutOnly<T>(T);
+
+impl<T> MutOnly<T> {
+    pub(crate) fn new(value: T) -> Self {
+        Self(value)
+    }
+
+    pub(crate) fn get_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
+}
+
+/// SAFETY: The type does not let anyone get a &T so Sync is irrelevant.
+unsafe impl<T> Sync for MutOnly<T> {}


### PR DESCRIPTION
They are unnecessary as we ever only retrieve the futures from ex data to poll them, thus when we have mutable access to them, so Send is all we need.