### PR TITLE
Update CI to build for all matrix targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,10 +166,10 @@ jobs:
       run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
     - if: "startsWith(matrix.os, 'windows') && !contains(matrix.target, 'ios')"
       # CI's Windows doesn't have require root certs
-      run: cargo test --workspace --exclude tokio-boring --exclude hyper-boring
+      run: cargo test --workspace --target ${{ matrix.target }} --exclude tokio-boring --exclude hyper-boring
       name: Run tests (Windows)
     - if: "!startsWith(matrix.os, 'windows') && !contains(matrix.target, 'ios')"
-      run: cargo test
+      run: cargo test --target ${{ matrix.target }}
       name: Run tests (not Windows)
     - if: "contains(matrix.target, 'ios')"
       # It's... theoretically possible to run tests on iPhone Simulator,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,15 +211,14 @@ jobs:
     - name: Set Android Linker path
       if: endsWith(matrix.thing, '-android')
       run: echo "CARGO_TARGET_$(echo ${{ matrix.target }} | tr \\-a-z _A-Z)_LINKER=$ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64/bin/$(echo ${{ matrix.target }} | sed s/armv7/armv7a/)21-clang++" >> "$GITHUB_ENV"
-    - if: "!matrix.check_only"
-      run: cargo test --target ${{ matrix.target }} ${{ matrix.extra_test_args }}
-      name: Run tests
+    - name: Build tests
+      # We `build` because we want the linker to verify we are cross-compiling correctly for check-only targets.
+      run: cargo build --target ${{ matrix.target }} --tests ${{ matrix.extra_test_args }}
       shell: bash
       env: ${{ matrix.custom_env }}
-    - if: matrix.check_only
-      # We `build` because we want the linker to verify we are cross-compiling correctly.
-      run: cargo build --target ${{ matrix.target }} --tests
-      name: Build tests
+    - name: Run tests
+      if: "!matrix.check_only"
+      run: cargo test --target ${{ matrix.target }} ${{ matrix.extra_test_args }}
       shell: bash
       env: ${{ matrix.custom_env }}
     - name: Test boring-sys cargo publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,7 @@ jobs:
         - check_only: false
         - extra_test_args: ''
         - apt_packages: ''
+        - custom_env: {}
         - thing: stable
           target: x86_64-unknown-linux-gnu
           rust: stable
@@ -136,12 +137,20 @@ jobs:
           os: ubuntu-latest
           apt_packages: gcc-arm-linux-gnueabi g++-arm-linux-gnueabi
           check_only: true
+          custom_env:
+            CC: arm-linux-gnueabi-gcc
+            CXX: arm-linux-gnueabi-g++
+            CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABI_LINKER: arm-linux-gnueabi-g++
         - thing: aarch64-linux
           target: aarch64-unknown-linux-gnu
           rust: stable
           os: ubuntu-latest
           apt_packages: crossbuild-essential-arm64
           check_only: true
+          custom_env:
+            CC: aarch64-linux-gnu-gcc
+            CXX: aarch64-linux-gnu-g++
+            CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-g++
         - thing: x86_64-mingw
           target: x86_64-pc-windows-gnu
           rust: stable
@@ -187,10 +196,12 @@ jobs:
     - if: "!matrix.check_only"
       run: cargo test --target ${{ matrix.target }} ${{ matrix.extra_test_args }}
       name: Run tests
+      env: ${{ matrix.custom_env }}
     - if: matrix.check_only
       # We `build` because we want the linker to verify we are cross-compiling correctly.
       run: cargo build --target ${{ matrix.target }} --tests
       name: Build tests
+      env: ${{ matrix.custom_env }}
     - name: Test boring-sys cargo publish
       # Running `cargo publish --dry-run` tests two things:
       #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,7 @@ jobs:
         include:
         - check_only: false
         - extra_test_args: ''
+        - apt_packages: ''
         - thing: stable
           target: x86_64-unknown-linux-gnu
           rust: stable
@@ -120,7 +121,6 @@ jobs:
         - thing: x86_64-ios
           target: x86_64-apple-ios
           os: macos-latest
-
           check_only: true
         - thing: i686-linux
           target: i686-unknown-linux-gnu
@@ -164,8 +164,8 @@ jobs:
       shell: bash
     - run: rustup target add ${{ matrix.target }}
     - name: Install Linux cross-compile dependencies
-      if: "contains(matrix.target, 'linux') && !startsWith(matrix.target, 'x86_64')"
-      run: sudo apt install -y gcc-multilib g++-multilib
+      if: "matrix.apt_packages != ''"
+      run: sudo apt update && sudo apt install -y ${{ matrix.apt_packages }}
       shell: bash
     - name: Install nasm
       if: startsWith(matrix.os, 'windows')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,18 +96,22 @@ jobs:
           target: arm-linux-androideabi
           rust: stable
           os: ubuntu-latest
+          check_only: true
         - thing: arm64-android
           target: aarch64-linux-android
           rust: stable
           os: ubuntu-latest
+          check_only: true
         - thing: i686-android
           target: i686-linux-android
           rust: stable
           os: ubuntu-latest
+          check_only: true
         - thing: x86_64-android
           target: x86_64-linux-android
           rust: stable
           os: ubuntu-latest
+          check_only: true
         - thing: aarch64-ios
           target: aarch64-apple-ios
           os: macos-latest
@@ -126,14 +130,19 @@ jobs:
           target: i686-unknown-linux-gnu
           rust: stable
           os: ubuntu-latest
+          apt_packages: gcc-multilib g++-multilib
         - thing: arm-linux
           target: arm-unknown-linux-gnueabi
           rust: stable
           os: ubuntu-latest
+          apt_packages: gcc-arm-linux-gnueabi g++-arm-linux-gnueabi
+          check_only: true
         - thing: aarch64-linux
           target: aarch64-unknown-linux-gnu
           rust: stable
           os: ubuntu-latest
+          apt_packages: crossbuild-essential-arm64
+          check_only: true
         - thing: x86_64-musl
           target: x86_64-unknown-linux-musl
           rust: stable
@@ -163,7 +172,7 @@ jobs:
       run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
       shell: bash
     - run: rustup target add ${{ matrix.target }}
-    - name: Install Linux cross-compile dependencies
+    - name: Install target-specific APT dependencies
       if: "matrix.apt_packages != ''"
       run: sudo apt update && sudo apt install -y ${{ matrix.apt_packages }}
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,11 +205,13 @@ jobs:
     - if: "!matrix.check_only"
       run: cargo test --target ${{ matrix.target }} ${{ matrix.extra_test_args }}
       name: Run tests
+      shell: bash
       env: ${{ matrix.custom_env }}
     - if: matrix.check_only
       # We `build` because we want the linker to verify we are cross-compiling correctly.
       run: cargo build --target ${{ matrix.target }} --tests
       name: Build tests
+      shell: bash
       env: ${{ matrix.custom_env }}
     - name: Test boring-sys cargo publish
       # Running `cargo publish --dry-run` tests two things:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,8 +188,9 @@ jobs:
       run: cargo test --target ${{ matrix.target }} ${{ matrix.extra_test_args }}
       name: Run tests
     - if: matrix.check_only
-      run: cargo check --target ${{ matrix.target }} --all-targets
-      name: Check tests
+      # We `build` because we want the linker to verify we are cross-compiling correctly.
+      run: cargo build --target ${{ matrix.target }} --tests
+      name: Build tests
     - name: Test boring-sys cargo publish
       # Running `cargo publish --dry-run` tests two things:
       #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,16 @@ jobs:
         - thing: x86_64-mingw
           target: x86_64-pc-windows-gnu
           rust: stable
-          os: ubuntu-latest
+          os: windows-latest
+          check_only: true # tests are flaky for unclear reasons
+          custom_env:
+            CC: gcc
+            CXX: g++
+            C_INCLUDE_PATH: "C:\\msys64\\usr\\include"
+            CPLUS_INCLUDE_PATH: "C:\\msys64\\usr\\include"
+            LIBRARY_PATH: "C:\\msys64\\usr\\lib"
+          # CI's Windows doesn't have required root certs
+          extra_test_args: --workspace --exclude tokio-boring --exclude hyper-boring
         - thing: i686-msvc
           target: i686-pc-windows-msvc
           rust: stable-x86_64-msvc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,8 @@ jobs:
         - i686-msvc
         - x86_64-msvc
         include:
+        - check_only: false
+        - extra_test_args: ''
         - thing: stable
           target: x86_64-unknown-linux-gnu
           rust: stable
@@ -108,12 +110,18 @@ jobs:
         - thing: aarch64-ios
           target: aarch64-apple-ios
           os: macos-latest
+          check_only: true
+          # It's... theoretically possible to run tests on iPhone Simulator,
+          # but for now, make sure that BoringSSL only builds.
         - thing: aarch64-ios-sim
           target: aarch64-apple-ios-sim
           os: macos-latest
+          check_only: true
         - thing: x86_64-ios
           target: x86_64-apple-ios
           os: macos-latest
+
+          check_only: true
         - thing: i686-linux
           target: i686-unknown-linux-gnu
           rust: stable
@@ -138,10 +146,14 @@ jobs:
           target: i686-pc-windows-msvc
           rust: stable-x86_64-msvc
           os: windows-latest
+          # CI's Windows doesn't have required root certs
+          extra_test_args: --workspace --exclude tokio-boring --exclude hyper-boring
         - thing: x86_64-msvc
           target: x86_64-pc-windows-msvc
           rust: stable-x86_64-msvc
           os: windows-latest
+          # CI's Windows doesn't have required root certs
+          extra_test_args: --workspace --exclude tokio-boring --exclude hyper-boring
 
     steps:
     - uses: actions/checkout@v2
@@ -151,6 +163,10 @@ jobs:
       run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
       shell: bash
     - run: rustup target add ${{ matrix.target }}
+    - name: Install Linux cross-compile dependencies
+      if: "contains(matrix.target, 'linux') && !startsWith(matrix.target, 'x86_64')"
+      run: sudo apt install -y gcc-multilib g++-multilib
+      shell: bash
     - name: Install nasm
       if: startsWith(matrix.os, 'windows')
       run: choco install nasm
@@ -164,18 +180,12 @@ jobs:
     - name: Set LIBCLANG_PATH
       if: startsWith(matrix.os, 'windows')
       run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
-    - if: "startsWith(matrix.os, 'windows') && !contains(matrix.target, 'ios')"
-      # CI's Windows doesn't have require root certs
-      run: cargo test --workspace --target ${{ matrix.target }} --exclude tokio-boring --exclude hyper-boring
-      name: Run tests (Windows)
-    - if: "!startsWith(matrix.os, 'windows') && !contains(matrix.target, 'ios')"
-      run: cargo test --target ${{ matrix.target }}
-      name: Run tests (not Windows)
-    - if: "contains(matrix.target, 'ios')"
-      # It's... theoretically possible to run tests on iPhone Simulator,
-      # but for now, make sure that BoringSSL only builds.
+    - if: "!matrix.check_only"
+      run: cargo test --target ${{ matrix.target }} ${{ matrix.extra_test_args }}
+      name: Run tests
+    - if: matrix.check_only
       run: cargo check --target ${{ matrix.target }} --all-targets
-      name: Check tests (iOS)
+      name: Check tests
     - name: Test boring-sys cargo publish
       # Running `cargo publish --dry-run` tests two things:
       #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,6 @@ jobs:
       matrix:
         thing:
         - stable
-        - macos-x86_64
         - arm-android
         - arm64-android
         - i686-android
@@ -76,6 +75,8 @@ jobs:
         - i686-linux
         - arm-linux
         - aarch64-linux
+        - arm64-macos
+        - x86_64-macos
         - x86_64-mingw
         - i686-msvc
         - x86_64-msvc
@@ -88,10 +89,6 @@ jobs:
           target: x86_64-unknown-linux-gnu
           rust: stable
           os: ubuntu-latest
-        - thing: macos-x86_64
-          target: x86_64-apple-darwin
-          rust: stable
-          os: macos-latest
         - thing: arm-android
           target: armv7-linux-androideabi
           rust: stable
@@ -151,6 +148,15 @@ jobs:
             CC: aarch64-linux-gnu-gcc
             CXX: aarch64-linux-gnu-g++
             CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-g++
+        - thing: arm64-macos
+          target: aarch64-apple-darwin
+          rust: stable
+          os: macos-latest
+          check_only: true
+        - thing: x86_64-macos
+          target: x86_64-apple-darwin
+          rust: stable
+          os: macos-latest
         - thing: x86_64-mingw
           target: x86_64-pc-windows-gnu
           rust: stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,6 @@ jobs:
         - i686-linux
         - arm-linux
         - aarch64-linux
-        - x86_64-musl
         - x86_64-mingw
         - i686-msvc
         - x86_64-msvc
@@ -143,10 +142,6 @@ jobs:
           os: ubuntu-latest
           apt_packages: crossbuild-essential-arm64
           check_only: true
-        - thing: x86_64-musl
-          target: x86_64-unknown-linux-musl
-          rust: stable
-          os: ubuntu-latest
         - thing: x86_64-mingw
           target: x86_64-pc-windows-gnu
           rust: stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
           rust: stable
           os: macos-latest
         - thing: arm-android
-          target: arm-linux-androideabi
+          target: armv7-linux-androideabi
           rust: stable
           os: ubuntu-latest
           check_only: true
@@ -193,6 +193,9 @@ jobs:
     - name: Set LIBCLANG_PATH
       if: startsWith(matrix.os, 'windows')
       run: echo "LIBCLANG_PATH=$((gcm clang).source -replace "clang.exe")" >> $env:GITHUB_ENV
+    - name: Set Android Linker path
+      if: endsWith(matrix.thing, '-android')
+      run: echo "CARGO_TARGET_$(echo ${{ matrix.target }} | tr \\-a-z _A-Z)_LINKER=$ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64/bin/$(echo ${{ matrix.target }} | sed s/armv7/armv7a/)21-clang++" >> "$GITHUB_ENV"
     - if: "!matrix.check_only"
       run: cargo test --target ${{ matrix.target }} ${{ matrix.extra_test_args }}
       name: Run tests

--- a/boring-sys/build/config.rs
+++ b/boring-sys/build/config.rs
@@ -8,7 +8,6 @@ pub(crate) struct Config {
     pub(crate) host: String,
     pub(crate) target: String,
     pub(crate) target_arch: String,
-    pub(crate) target_env: String,
     pub(crate) target_os: String,
     pub(crate) features: Features,
     pub(crate) env: Env,
@@ -42,7 +41,6 @@ impl Config {
         let host = env::var("HOST").unwrap();
         let target = env::var("TARGET").unwrap();
         let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
-        let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap();
         let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
 
         let features = Features::from_env();
@@ -58,7 +56,6 @@ impl Config {
             host,
             target,
             target_arch,
-            target_env,
             target_os,
             features,
             env,

--- a/boring-sys/build/main.rs
+++ b/boring-sys/build/main.rs
@@ -153,7 +153,7 @@ fn get_boringssl_source_path(config: &Config) -> &PathBuf {
 /// so adjust library location based on platform and build target.
 /// See issue: https://github.com/alexcrichton/cmake-rs/issues/18
 fn get_boringssl_platform_output_path(config: &Config) -> String {
-    if config.target_env == "msvc" {
+    if config.target.ends_with("-msvc") {
         // Code under this branch should match the logic in cmake-rs
         let debug_env_var = config
             .env

--- a/boring-sys/build/main.rs
+++ b/boring-sys/build/main.rs
@@ -676,6 +676,7 @@ fn main() {
         .size_t_is_usize(true)
         .layout_tests(true)
         .prepend_enum_name(true)
+        .blocklist_type("max_align_t") // Not supported by bindgen on all targets, not used by BoringSSL
         .clang_args(get_extra_clang_args_for_bindgen(&config))
         .clang_arg("-I")
         .clang_arg(include_path.display().to_string());


### PR DESCRIPTION
We noticed that the CI matrix wasn’t always building for the Rust target it intended, leading to surprise breakage (e.g. #187) when doing release builds. This addresses that in a few ways:

1. add `--target` to `cargo test`
2. `check_only` flag
   - skip running tests for non-native architectures and targets; instead do `cargo build … --tests` to confirm cross-compilation
3. various customization options
   - specific packages required to cross-compile for the target, environment variables, etc.  
4. last resort: drop a target
   - musl doesn’t have a standard C++ setup to use
