### PR TITLE
Use replace_ex_data more

### DIFF
--- a/tokio-boring/src/async_callbacks.rs
+++ b/tokio-boring/src/async_callbacks.rs
@@ -298,7 +298,7 @@ fn with_ex_data_future<H, R, T, E>(
         match fut.as_mut().poll(&mut ctx) {
             Poll::Ready(fut_result) => Poll::Ready(into_result(fut_result)),
             Poll::Pending => {
-                get_ssl_mut(ssl_handle).set_ex_data(index, MutOnly::new(Some(fut)));
+                get_ssl_mut(ssl_handle).replace_ex_data(index, MutOnly::new(Some(fut)));
 
                 Poll::Pending
             }


### PR DESCRIPTION
Setting callbacks multiple times on a SslContextBuilder causes the previous callback installed to leak, using replace_ex_data internally prevents that.

We also start using it in tokio-boring in with_ex_data_future, my understanding is that the futures currently in use are never installed twice by that function but that could change in the future with the addition of more async callbacks.