### PR TITLE
hyper-boring: update to hyper 1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "4.1.0"
+version = "5.0.0"
 repository = "https://github.com/cloudflare/boring"
 edition = "2021"
 
@@ -19,9 +19,9 @@ tag-prefix = ""
 publish = false
 
 [workspace.dependencies]
-boring-sys = { version = "4.1.0", path = "./boring-sys" }
-boring = { version = "4.1.0", path = "./boring" }
-tokio-boring = { version = "4.1.0", path = "./tokio-boring" }
+boring-sys = { version = "5.0.0", path = "./boring-sys" }
+boring = { version = "5.0.0", path = "./boring" }
+tokio-boring = { version = "5.0.0", path = "./tokio-boring" }
 
 bindgen = { version = "0.68.1", default-features = false, features = ["runtime"] }
 cmake = "0.1.18"
@@ -36,8 +36,11 @@ futures = "0.3"
 tokio = "1"
 anyhow = "1"
 antidote = "1.0.0"
-http = "0.2"
-hyper = { version = "0.14", default-features = false }
+http = "1.0"
+hyper = { version = "1.0", default-features = false }
+hyper-util = "0.1"
+http-body-util = "0.1.0"
 linked_hash_set = "0.1"
 once_cell = "1.0"
 tower-layer = "0.3"
+tower-service = "0.3"

--- a/hyper-boring/Cargo.toml
+++ b/hyper-boring/Cargo.toml
@@ -15,9 +15,7 @@ features = ["rpk", "pq-experimental"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = ["runtime"]
-
-runtime = ["hyper/runtime"]
+default = []
 
 # Use a FIPS-validated version of boringssl.
 fips = ["tokio-boring/fips"]
@@ -31,15 +29,19 @@ pq-experimental = ["tokio-boring/pq-experimental"]
 [dependencies]
 antidote = { workspace = true }
 http = { workspace = true }
-hyper = { workspace = true, features = ["client"] }
+hyper = { workspace = true, default-features = false }
+hyper-util = { workspace = true, features = ["client-legacy", "client", "tokio"] }
 linked_hash_set = { workspace = true }
 once_cell = { workspace = true }
 boring = { workspace = true }
 tokio = { workspace = true }
 tokio-boring = { workspace = true }
 tower-layer = { workspace = true }
+tower-service = { workspace = true }
 
 [dev-dependencies]
 hyper = { workspace = true, features = [ "full" ] }
 tokio = { workspace = true, features = [ "full" ] }
 futures = { workspace = true }
+hyper-util = { workspace = true, features = ["full"] }
+http-body-util = { workspace = true }


### PR DESCRIPTION
This PR upgrades hyper-boring to support hyper 1.0.0-rc.3. Most of this is by moving dependencies from hyper core to hyper-util, as much of the functionality we depend on has been removed from the core.

Copied from https://github.com/cloudflare/boring/pull/107 since I made an unrepairable mistake on the first PR