### PR TITLE
bound session cache

### DIFF
--- a/hyper-boring/src/lib.rs
+++ b/hyper-boring/src/lib.rs
@@ -80,8 +80,14 @@ pub struct HttpsLayer {
 
 /// Settings for [`HttpsLayer`]
 pub struct HttpsLayerSettings {
-    /// Maximum number of sessions to cache. Session capacity is per session key (domain).
-    pub session_cache_capacity: usize,
+    session_cache_capacity: usize,
+}
+
+impl HttpsLayerSettings {
+    /// Constructs an [`HttpsLayerSettingsBuilder`] for configuring settings
+    pub fn builder() -> HttpsLayerSettingsBuilder {
+        HttpsLayerSettingsBuilder(HttpsLayerSettings::default())
+    }
 }
 
 impl Default for HttpsLayerSettings {
@@ -89,6 +95,22 @@ impl Default for HttpsLayerSettings {
         Self {
             session_cache_capacity: 8,
         }
+    }
+}
+
+/// Builder for [`HttpsLayerSettings`]
+pub struct HttpsLayerSettingsBuilder(HttpsLayerSettings);
+
+impl HttpsLayerSettingsBuilder {
+    /// Sets maximum number of sessions to cache. Session capacity is per session key (domain).
+    /// Defaults to 8.
+    pub fn set_session_cache_capacity(&mut self, capacity: usize) {
+        self.0.session_cache_capacity = capacity;
+    }
+
+    /// Consumes the builder, returning a new [`HttpsLayerSettings`]
+    pub fn build(self) -> HttpsLayerSettings {
+        self.0
     }
 }
 

--- a/hyper-boring/src/lib.rs
+++ b/hyper-boring/src/lib.rs
@@ -78,6 +78,20 @@ pub struct HttpsLayer {
     inner: Inner,
 }
 
+/// Settings for [`HttpsLayer`]
+pub struct HttpsLayerSettings {
+    /// Maximum number of sessions to cache. Session capacity is per session key (domain).
+    pub session_cache_capacity: usize,
+}
+
+impl Default for HttpsLayerSettings {
+    fn default() -> Self {
+        Self {
+            session_cache_capacity: 8,
+        }
+    }
+}
+
 impl HttpsLayer {
     /// Creates a new `HttpsLayer` with default settings.
     ///
@@ -94,18 +108,17 @@ impl HttpsLayer {
     ///
     /// The session cache configuration of `ssl` will be overwritten.
     pub fn with_connector(ssl: SslConnectorBuilder) -> Result<HttpsLayer, ErrorStack> {
-        Self::with_connector_and_capacity(ssl, 8)
+        Self::with_connector_and_settings(ssl, Default::default())
     }
 
-    /// Creates a new `HttpsLayer` with session capacity.
-    ///
-    /// The session cache configuration of `ssl` will be overwritten. Session capacity is per
-    /// session key (domain).
-    pub fn with_connector_and_capacity(
+    /// Creates a new `HttpsLayer` with settings
+    pub fn with_connector_and_settings(
         mut ssl: SslConnectorBuilder,
-        capacity: usize,
+        settings: HttpsLayerSettings,
     ) -> Result<HttpsLayer, ErrorStack> {
-        let cache = Arc::new(Mutex::new(SessionCache::with_capacity(capacity)));
+        let cache = Arc::new(Mutex::new(SessionCache::with_capacity(
+            settings.session_cache_capacity,
+        )));
 
         ssl.set_session_cache_mode(SslSessionCacheMode::CLIENT);
 

--- a/hyper-boring/src/lib.rs
+++ b/hyper-boring/src/lib.rs
@@ -93,8 +93,19 @@ impl HttpsLayer {
     /// Creates a new `HttpsLayer`.
     ///
     /// The session cache configuration of `ssl` will be overwritten.
-    pub fn with_connector(mut ssl: SslConnectorBuilder) -> Result<HttpsLayer, ErrorStack> {
-        let cache = Arc::new(Mutex::new(SessionCache::new()));
+    pub fn with_connector(ssl: SslConnectorBuilder) -> Result<HttpsLayer, ErrorStack> {
+        Self::with_connector_and_capacity(ssl, 8)
+    }
+
+    /// Creates a new `HttpsLayer` with session capacity.
+    ///
+    /// The session cache configuration of `ssl` will be overwritten. Session capacity is per
+    /// session key (domain).
+    pub fn with_connector_and_capacity(
+        mut ssl: SslConnectorBuilder,
+        capacity: usize,
+    ) -> Result<HttpsLayer, ErrorStack> {
+        let cache = Arc::new(Mutex::new(SessionCache::with_capacity(capacity)));
 
         ssl.set_session_cache_mode(SslSessionCacheMode::CLIENT);
 
@@ -105,11 +116,6 @@ impl HttpsLayer {
                     cache.lock().insert(key.clone(), session);
                 }
             }
-        });
-
-        ssl.set_remove_session_callback({
-            let cache = cache.clone();
-            move |_, session| cache.lock().remove(session)
         });
 
         Ok(HttpsLayer {


### PR DESCRIPTION
When establishing new TLS sessions, servers may send multiple session tickets (RFC8446 4.6.1). hyper-boring caches tickets without placing a limit on how many tickets are cached. This leads to unbounded growth of hyper-boring's cache and leaves clients vulnerable to malicious servers who might send many session tickets to exhaust a client's available memory.

This change bounds the cache to a default of 8 tickets.