### PR TITLE
Fix building with non bazel commits of boringssl

### DIFF
--- a/boring-sys/build/config.rs
+++ b/boring-sys/build/config.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 pub(crate) struct Config {
     pub(crate) manifest_dir: PathBuf,
     pub(crate) out_dir: PathBuf,
+    pub(crate) is_bazel: bool,
     pub(crate) host: String,
     pub(crate) target: String,
     pub(crate) target_arch: String,
@@ -51,9 +52,15 @@ impl Config {
             features.fips || features.fips_link_precompiled,
         );
 
+        let mut is_bazel = false;
+        if let Some(src_path) = &env.source_path {
+            is_bazel = src_path.join("src").exists();
+        }
+
         let config = Self {
             manifest_dir,
             out_dir,
+            is_bazel,
             host,
             target,
             target_arch,

--- a/boring-sys/patches/rpk.patch
+++ b/boring-sys/patches/rpk.patch
@@ -347,9 +347,9 @@ index 8d5a23872..b9ac70dfe 100644
  
 @@ -150,6 +169,7 @@ SSL_HANDSHAKE::SSL_HANDSHAKE(SSL *ssl_arg)
        cert_compression_negotiated(false),
++      server_certificate_type_negotiated(false),
        apply_jdk11_workaround(false),
        can_release_private_key(false),
-+      server_certificate_type_negotiated(false),
        channel_id_negotiated(false) {
    assert(ssl);
  


### PR DESCRIPTION
We need to add `/build/crypto` and `/build/ssl` to the library search path to handle the case where we pass `BORING_BSSL_SOURCE_PATH` when building without enabling any fips features. Otherwise, non bazel commits will not work because `/build/` itself will not contain any crypto libraries to link with