### PR TITLE
Fix building with BORING_BSSL_PATH / BORING_BSSL_FIPS_PATH

### DIFF
--- a/boring-sys/build/main.rs
+++ b/boring-sys/build/main.rs
@@ -637,7 +637,7 @@ fn main() {
     let bssl_dir = built_boring_source_path(&config);
     let build_path = get_boringssl_platform_output_path(&config);
 
-    if config.is_bazel {
+    if config.is_bazel || (config.features.fips && config.env.path.is_some()) {
         println!(
             "cargo:rustc-link-search=native={}/lib/{}",
             bssl_dir.display(),


### PR DESCRIPTION
When passing BORING_BSSL_FIPS_PATH, you need to add /lib/ to the search path, and when passing BORING_BSSL_PATH you need to add /crypto/ and /ssl/ to the search path.