### PR TITLE
Enable layout tests on iOS target

### DIFF
--- a/boring-sys/build/main.rs
+++ b/boring-sys/build/main.rs
@@ -709,21 +709,6 @@ fn main() {
             .clang_arg(sysroot.display().to_string());
     }
 
-    match &*config.target {
-        // bindgen produces alignment tests that cause undefined behavior [1]
-        // when applied to explicitly unaligned types like OSUnalignedU64.
-        //
-        // There is no way to disable these tests for only some types
-        // and it's not nice to suppress warnings for the entire crate,
-        // so let's disable all alignment tests and hope for the best.
-        //
-        // [1]: https://github.com/rust-lang/rust-bindgen/issues/1651
-        "aarch64-apple-ios" | "aarch64-apple-ios-sim" => {
-            builder = builder.layout_tests(false);
-        }
-        _ => {}
-    }
-
     let headers = [
         "aes.h",
         "asn1_mac.h",


### PR DESCRIPTION
Warnings of layout tests were already fixed in bindgen 0.60: https://github.com/rust-lang/rust-bindgen/issues/1651.