### PR TITLE
fix: invalid -L path for build artifact search

### DIFF
--- a/boring-sys/build/main.rs
+++ b/boring-sys/build/main.rs
@@ -645,19 +645,8 @@ fn main() {
         );
     } else {
         println!(
-            "cargo:rustc-link-search=native={}/build/crypto/{}",
+            "cargo:rustc-link-search=native={}/build",
             bssl_dir.display(),
-            build_path
-        );
-        println!(
-            "cargo:rustc-link-search=native={}/build/ssl/{}",
-            bssl_dir.display(),
-            build_path
-        );
-        println!(
-            "cargo:rustc-link-search=native={}/build/{}",
-            bssl_dir.display(),
-            build_path
         );
     }
 


### PR DESCRIPTION
I haven't managed to link boring for either Linux, windows or macOS without this modification recently, which I find strange

Do you have any idea of what could be happening ?