### PR TITLE
Updates license field to valid SPDX format

### DIFF
--- a/hyper-boring/Cargo.toml
+++ b/hyper-boring/Cargo.toml
@@ -4,7 +4,7 @@ version = { workspace = true }
 authors = ["Steven Fackler <sfackler@gmail.com>", "Ivan Nikulin <ifaaan@gmail.com>"]
 edition = { workspace = true }
 description = "Hyper TLS support via BoringSSL"
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 repository = { workspace = true }
 documentation = "https://docs.rs/hyper-boring"
 readme = "README.md"

--- a/tokio-boring/Cargo.toml
+++ b/tokio-boring/Cargo.toml
@@ -2,7 +2,7 @@
 name = "tokio-boring"
 version = { workspace = true }
 authors = ["Alex Crichton <alex@alexcrichton.com>", "Ivan Nikulin <ifaaan@gmail.com>"]
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 edition = { workspace = true }
 repository = { workspace = true }
 homepage = "https://github.com/cloudflare/boring"


### PR DESCRIPTION
The popular [`dependency-review-action`](https://github.com/actions/dependency-review-action) requires the license field be in valid SPDX format. (We are hitting false positives on this dependency via `dependency-review-action` over at [Teleport](https://github.com/gravitational/teleport)).