### PR TITLE
feat: add openharmony platform

### DIFF
--- a/boring-sys/build/config.rs
+++ b/boring-sys/build/config.rs
@@ -10,6 +10,7 @@ pub(crate) struct Config {
     pub(crate) target: String,
     pub(crate) target_arch: String,
     pub(crate) target_os: String,
+    pub(crate) target_env: String,
     pub(crate) features: Features,
     pub(crate) env: Env,
 }
@@ -44,6 +45,7 @@ impl Config {
         let target = env::var("TARGET").unwrap();
         let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
         let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap();
+        let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap();
 
         let features = Features::from_env();
         let env = Env::from_env(
@@ -65,6 +67,7 @@ impl Config {
             target,
             target_arch,
             target_os,
+            target_env,
             features,
             env,
         };

--- a/boring-sys/build/main.rs
+++ b/boring-sys/build/main.rs
@@ -707,6 +707,17 @@ fn main() {
         builder = builder
             .clang_arg("--sysroot")
             .clang_arg(sysroot.display().to_string());
+
+        let c_target = format!(
+            "{}-{}-{}",
+            &config.target_arch, &config.target_os, &config.target_env
+        );
+
+        // we need to add special platform header file with env for support cross building
+        let header = format!("{}/usr/include/{}", sysroot.display().to_string(), c_target);
+        if PathBuf::from(&header).is_dir() {
+            builder = builder.clang_arg("-I").clang_arg(&header);
+        }
     }
 
     let headers = [

--- a/boring/src/asn1.rs
+++ b/boring/src/asn1.rs
@@ -317,6 +317,8 @@ impl Asn1Time {
         ffi::init();
 
         unsafe {
+            // for higher musl version, need to convert i32 to i64
+            // https://github.com/rust-lang/libc/issues/1848
             let handle = cvt_p(ffi::ASN1_TIME_set(ptr::null_mut(), time.into()))?;
             Ok(Asn1Time::from_ptr(handle))
         }

--- a/boring/src/asn1.rs
+++ b/boring/src/asn1.rs
@@ -317,7 +317,7 @@ impl Asn1Time {
         ffi::init();
 
         unsafe {
-            let handle = cvt_p(ffi::ASN1_TIME_set(ptr::null_mut(), time))?;
+            let handle = cvt_p(ffi::ASN1_TIME_set(ptr::null_mut(), time.into()))?;
             Ok(Asn1Time::from_ptr(handle))
         }
     }


### PR DESCRIPTION
1. With more recent versions of musl, i32 needs to be converted into i64 type. If not, it will result in a compilation error.

2. 