### PR TITLE
Fix x509_check_host return value

### DIFF
--- a/boring/src/x509/mod.rs
+++ b/boring/src/x509/mod.rs
@@ -601,7 +601,7 @@ impl X509Ref {
                 0,
                 std::ptr::null_mut(),
             ))
-            .map(|n| n != 0)
+            .map(|n| n == 1)
         }
     }
 


### PR DESCRIPTION
The [x509_check_host docs](https://commondatastorage.googleapis.com/chromium-boringssl-docs/x509.h.html#X509_check_host) state:
> X509_check_host checks if x509 matches the DNS name chk. It returns one on match, zero on mismatch, or a negative number on error. 

The current implementation will return `true` for 1, -1, and -2, therefore returning an incorrect value if any of the above error cases are [hit](https://github.com/google/boringssl/blob/44b3df6f03d85c901767250329c571db405122d5/src/crypto/x509v3/v3_utl.c#L1036-L1045).