### PR TITLE
Add SslCurve::to_nid() and remove SslCurveId

### DIFF
--- a/boring/src/ssl/test/mod.rs
+++ b/boring/src/ssl/test/mod.rs
@@ -13,7 +13,7 @@ use crate::pkey::PKey;
 use crate::srtp::SrtpProfileId;
 use crate::ssl::test::server::Server;
 use crate::ssl::SslVersion;
-use crate::ssl::{self, SslCurveId};
+use crate::ssl::{self, SslCurve};
 use crate::ssl::{
     ExtensionType, ShutdownResult, ShutdownState, Ssl, SslAcceptor, SslAcceptorBuilder,
     SslConnector, SslContext, SslFiletype, SslMethod, SslOptions, SslStream, SslVerifyMode,
@@ -931,11 +931,11 @@ fn get_curve() {
 
 #[test]
 fn get_curve_name() {
-    assert_eq!(SslCurveId::SECP224R1.name(), Some("P-224"));
-    assert_eq!(SslCurveId::SECP256R1.name(), Some("P-256"));
-    assert_eq!(SslCurveId::SECP384R1.name(), Some("P-384"));
-    assert_eq!(SslCurveId::SECP521R1.name(), Some("P-521"));
-    assert_eq!(SslCurveId::X25519.name(), Some("X25519"));
+    assert_eq!(SslCurve::SECP224R1.name(), Some("P-224"));
+    assert_eq!(SslCurve::SECP256R1.name(), Some("P-256"));
+    assert_eq!(SslCurve::SECP384R1.name(), Some("P-384"));
+    assert_eq!(SslCurve::SECP521R1.name(), Some("P-521"));
+    assert_eq!(SslCurve::X25519.name(), Some("X25519"));
 }
 
 #[test]


### PR DESCRIPTION
We previously added an `SslCurveId` struct to house SSL_CURVE variants of the internal NID constants, to allow `SslRef::curve()` to properly instantiate `SslCurve` structures. This was done to ensure `SslRef::set_curves()` did not break, as it expects the internal NID constants instead of the public SSL_CURVE ones. In future versions of boringssl, this problem is solved by virtue of the SSL_CTX_set1_group_ids API. Since we don't have this yet, this commit adds `SslCurve::nid()` so `SslRef::set_curves()` can convert the SSL_CURVE constants to the internal NID representation internally without breaking the public API.