### PR TITLE
Prepare for syncing with upstream

### DIFF
--- a/boring-sys/build/config.rs
+++ b/boring-sys/build/config.rs
@@ -34,6 +34,7 @@ pub(crate) struct Env {
     pub(crate) opt_level: Option<OsString>,
     pub(crate) android_ndk_home: Option<PathBuf>,
     pub(crate) cmake_toolchain_file: Option<PathBuf>,
+    pub(crate) cpp_runtime_lib: Option<OsString>,
 }
 
 impl Config {
@@ -164,6 +165,7 @@ impl Env {
             opt_level: target_var("OPT_LEVEL"),
             android_ndk_home: target_var("ANDROID_NDK_HOME").map(Into::into),
             cmake_toolchain_file: target_var("CMAKE_TOOLCHAIN_FILE").map(Into::into),
+            cpp_runtime_lib: target_var("BORING_BSSL_RUST_CPPLIB").map(Into::into),
         }
     }
 }

--- a/boring-sys/build/main.rs
+++ b/boring-sys/build/main.rs
@@ -1,4 +1,5 @@
 use fslock::LockFile;
+use std::env;
 use std::ffi::OsString;
 use std::fs;
 use std::io;
@@ -636,6 +637,22 @@ fn link_in_precompiled_bcm_o(config: &Config) {
     .unwrap();
 }
 
+fn get_cpp_runtime_lib(config: &Config) -> Option<String> {
+    if let Some(ref cpp_lib) = config.env.cpp_runtime_lib {
+        return cpp_lib.clone().into_string().ok();
+    }
+
+    // TODO(rmehra): figure out how to do this for windows
+    if env::var_os("CARGO_CFG_UNIX").is_some() {
+        match env::var("CARGO_CFG_TARGET_OS").unwrap().as_ref() {
+            "macos" | "ios" => Some("c++".into()),
+            _ => Some("stdc++".into()),
+        }
+    } else {
+        None
+    }
+}
+
 fn main() {
     let config = Config::from_env();
     let bssl_dir = built_boring_source_path(&config);
@@ -669,6 +686,9 @@ fn main() {
         link_in_precompiled_bcm_o(&config);
     }
 
+    if let Some(cpp_lib) = get_cpp_runtime_lib(&config) {
+        println!("cargo:rustc-link-lib={}", cpp_lib);
+    }
     println!("cargo:rustc-link-lib=static=crypto");
     println!("cargo:rustc-link-lib=static=ssl");
 

--- a/boring/src/x509/tests/trusted_first.rs
+++ b/boring/src/x509/tests/trusted_first.rs
@@ -93,12 +93,12 @@ fn verify(
 
     let mut store_ctx = X509StoreContext::new().unwrap();
 
-    let _ = store_ctx.init(&trusted, cert, &untrusted, |ctx| {
-        configure(ctx.verify_param_mut());
-        ctx.verify_cert().unwrap();
+    store_ctx
+        .init(&trusted, cert, &untrusted, |ctx| {
+            configure(ctx.verify_param_mut());
+            ctx.verify_cert().unwrap();
 
-        Ok(())
-    });
-
-    store_ctx.verify_result()
+            Ok(ctx.verify_result())
+        })
+        .expect("failed to obtain X509VerifyResult")
 }


### PR DESCRIPTION
* Support linking with a runtime cpp library
> As of https://boringssl-review.googlesource.com/c/boringssl/+/66288,
libssl allows a C++ runtime dependency. As such, we need to link with a
cpp runtime library. Implementation is inspired heavily from
https://github.com/google/boringssl/commit/54c956b2e668e11c75f1ee0367f1b3a0ad28eff9. Before releasing this change, we'll need to figure out a way to support
this for windows.

* Fix bug with accessing memzero'd X509StoreContext in tests
> As of https://boringssl-review.googlesource.com/c/boringssl/+/64141,
X509_STORE_CTX_cleanup will zero the memory allocated to the
X509_STORE_CTX. Because X509StoreContextRef::init invokes
X509_STORE_CTX_cleanup once the with_context closure has finished,
calling X509StoreContextRef::verify_result (or any API really) is going
to be invalid because memory has been zerod out. This is a pretty big
footgun, so maybe we should consider screaming a bit louder for this
case.

This patch doesn't sync with upstream _yet_, because all of our patches break due to upstream directory structure changes, and the RPK patch needs to be completely reworked