### PR TITLE
Expose SSL(_CTX)_set1_curves_list

### DIFF
--- a/boring/src/ssl/mod.rs
+++ b/boring/src/ssl/mod.rs
@@ -1794,6 +1794,24 @@ impl SslContextBuilder {
     // If the "kx-*" flags are used to set key exchange preference, then don't allow the user to
     // set them here. This ensures we don't override the user's preference without telling them:
     // when the flags are used, the preferences are set just before connecting or accepting.
+    #[cfg(not(feature = "kx-safe-default"))]
+    #[corresponds(SSL_CTX_set1_curves_list)]
+    pub fn set_curves_list(&mut self, curves: &str) -> Result<(), ErrorStack> {
+        let curves = CString::new(curves).unwrap();
+        unsafe {
+            cvt_0i(ffi::SSL_CTX_set1_curves_list(
+                self.as_ptr(),
+                curves.as_ptr() as *const _,
+            ))
+            .map(|_| ())
+        }
+    }
+
+    /// Sets the context's supported curves.
+    //
+    // If the "kx-*" flags are used to set key exchange preference, then don't allow the user to
+    // set them here. This ensures we don't override the user's preference without telling them:
+    // when the flags are used, the preferences are set just before connecting or accepting.
     #[corresponds(SSL_CTX_set1_curves)]
     #[cfg(not(feature = "kx-safe-default"))]
     pub fn set_curves(&mut self, curves: &[SslCurve]) -> Result<(), ErrorStack> {
@@ -2589,11 +2607,10 @@ impl SslRef {
     }
 
     #[corresponds(SSL_set1_curves_list)]
-    #[cfg(feature = "kx-safe-default")]
-    fn set_curves_list(&mut self, curves: &str) -> Result<(), ErrorStack> {
+    pub fn set_curves_list(&mut self, curves: &str) -> Result<(), ErrorStack> {
         let curves = CString::new(curves).unwrap();
         unsafe {
-            cvt(ffi::SSL_set1_curves_list(
+            cvt_0i(ffi::SSL_set1_curves_list(
                 self.as_ptr(),
                 curves.as_ptr() as *const _,
             ))


### PR DESCRIPTION
set_surves_list is similar to set_curves, but the curves are specified by a string. This makes it convenient when the supported curves of the underlying BoringSSL is not known at compile time.

Also fix a bug in checking return value of SSL_set1_curves_list.