### PR TITLE
Update bindgen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ boring-sys = { version = "4.9.1", path = "./boring-sys" }
 boring = { version = "4.9.1", path = "./boring" }
 tokio-boring = { version = "4.9.1", path = "./tokio-boring" }
 
-bindgen = { version = "0.68.1", default-features = false, features = ["runtime"] }
+bindgen = { version = "0.70.1", default-features = false, features = ["runtime"] }
 cmake = "0.1.18"
 fs_extra = "1.3.0"
 fslock = "0.2"


### PR DESCRIPTION
bindgen has had a lot of improvements recently, and this newer version is able to compile libbssl within edgeworker