### PR TITLE
Don't enable support for X25519MLKEM768 by default (yet)

### DIFF
--- a/boring/src/ssl/mod.rs
+++ b/boring/src/ssl/mod.rs
@@ -2693,13 +2693,13 @@ impl SslRef {
             if cfg!(feature = "kx-client-nist-required") {
                 "P256Kyber768Draft00:P-256:P-384:P-521"
             } else {
-                "X25519Kyber768Draft00:X25519MLKEM768:X25519:P256Kyber768Draft00:P-256:P-384:P-521"
+                "X25519Kyber768Draft00:X25519:P256Kyber768Draft00:P-256:P-384:P-521"
             }
         } else if cfg!(feature = "kx-client-pq-supported") {
             if cfg!(feature = "kx-client-nist-required") {
                 "P-256:P-384:P-521:P256Kyber768Draft00"
             } else {
-                "X25519:P-256:P-384:P-521:X25519MLKEM768:X25519Kyber768Draft00:P256Kyber768Draft00"
+                "X25519:P-256:P-384:P-521:X25519Kyber768Draft00:P256Kyber768Draft00"
             }
         } else {
             if cfg!(feature = "kx-client-nist-required") {
@@ -2715,10 +2715,8 @@ impl SslRef {
 
     #[cfg(feature = "kx-safe-default")]
     fn server_set_default_curves_list(&mut self) {
-        self.set_curves_list(
-            "X25519Kyber768Draft00:X25519MLKEM768:P256Kyber768Draft00:X25519:P-256:P-384",
-        )
-        .expect("invalid default server curves list");
+        self.set_curves_list("X25519Kyber768Draft00:P256Kyber768Draft00:X25519:P-256:P-384")
+            .expect("invalid default server curves list");
     }
 
     /// Returns the [`SslCurve`] used for this `SslRef`.


### PR DESCRIPTION
There are users of the `kx-*` features that don't use the PQ patch. Those would break with an older version of BoringSSL.