### PR TITLE
Set MSRV to 1.70

### DIFF
--- a/boring-sys/build/main.rs
+++ b/boring-sys/build/main.rs
@@ -688,6 +688,7 @@ fn main() {
     });
 
     let mut builder = bindgen::Builder::default()
+        .rust_target(bindgen::RustTarget::Stable_1_68) // bindgen MSRV is 1.70, so this is enough
         .derive_copy(true)
         .derive_debug(true)
         .derive_default(true)


### PR DESCRIPTION
With the bindgen 0.70 upgrade, the default rust target is set to be 1.77, which becomes the de facto MSRV of boring-sys since the change.

This change makes sure that the MSRV of boring-sys is kept at 1.70, which is the same as that of bindgen.