### PR TITLE
Add "fips-compat" feature

### DIFF
--- a/boring/Cargo.toml
+++ b/boring/Cargo.toml
@@ -19,7 +19,12 @@ rustdoc-args = ["--cfg", "docsrs"]
 # Controlling the build
 
 # Use a FIPS-validated version of boringssl.
-fips = ["boring-sys/fips"]
+fips = ["fips-compat", "boring-sys/fips"]
+
+# Build with compatibility for the BoringSSL FIPS version, without enabling the
+# `fips` feature itself (useful e.g. if `fips-link-precompiled` is used with an
+# older BoringSSL version).
+fips-compat = []
 
 # Link with precompiled FIPS-validated `bcm.o` module.
 fips-link-precompiled = ["boring-sys/fips-link-precompiled"]

--- a/boring/src/bio.rs
+++ b/boring/src/bio.rs
@@ -19,9 +19,9 @@ impl<'a> Drop for MemBioSlice<'a> {
 
 impl<'a> MemBioSlice<'a> {
     pub fn new(buf: &'a [u8]) -> Result<MemBioSlice<'a>, ErrorStack> {
-        #[cfg(not(feature = "fips"))]
+        #[cfg(not(feature = "fips-compat"))]
         type BufLen = isize;
-        #[cfg(feature = "fips")]
+        #[cfg(feature = "fips-compat")]
         type BufLen = libc::c_int;
 
         ffi::init();

--- a/boring/src/ssl/mod.rs
+++ b/boring/src/ssl/mod.rs
@@ -774,10 +774,10 @@ impl SslCurve {
 
 /// A compliance policy.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-#[cfg(not(feature = "fips"))]
+#[cfg(not(feature = "fips-compat"))]
 pub struct CompliancePolicy(ffi::ssl_compliance_policy_t);
 
-#[cfg(not(feature = "fips"))]
+#[cfg(not(feature = "fips-compat"))]
 impl CompliancePolicy {
     /// Does nothing, however setting this does not undo other policies, so trying to set this is an error.
     pub const NONE: Self = Self(ffi::ssl_compliance_policy_t::ssl_compliance_policy_none);
@@ -1469,7 +1469,7 @@ impl SslContextBuilder {
     #[corresponds(SSL_CTX_set_alpn_protos)]
     pub fn set_alpn_protos(&mut self, protocols: &[u8]) -> Result<(), ErrorStack> {
         unsafe {
-            #[cfg_attr(not(feature = "fips"), allow(clippy::unnecessary_cast))]
+            #[cfg_attr(not(feature = "fips-compat"), allow(clippy::unnecessary_cast))]
             {
                 assert!(protocols.len() <= ProtosLen::MAX as usize);
             }
@@ -1813,7 +1813,7 @@ impl SslContextBuilder {
     /// version of BoringSSL which doesn't yet include these APIs.
     /// Once the submoduled fips commit is upgraded, these gates can be removed.
     #[corresponds(SSL_CTX_set_permute_extensions)]
-    #[cfg(not(feature = "fips"))]
+    #[cfg(not(feature = "fips-compat"))]
     pub fn set_permute_extensions(&mut self, enabled: bool) {
         unsafe { ffi::SSL_CTX_set_permute_extensions(self.as_ptr(), enabled as _) }
     }
@@ -1888,7 +1888,7 @@ impl SslContextBuilder {
     ///
     /// This feature isn't available in the certified version of BoringSSL.
     #[corresponds(SSL_CTX_set_compliance_policy)]
-    #[cfg(not(feature = "fips"))]
+    #[cfg(not(feature = "fips-compat"))]
     pub fn set_compliance_policy(&mut self, policy: CompliancePolicy) -> Result<(), ErrorStack> {
         unsafe { cvt_0i(ffi::SSL_CTX_set_compliance_policy(self.as_ptr(), policy.0)).map(|_| ()) }
     }
@@ -2160,9 +2160,9 @@ impl SslContextRef {
 #[derive(Debug)]
 pub struct GetSessionPendingError;
 
-#[cfg(not(feature = "fips"))]
+#[cfg(not(feature = "fips-compat"))]
 type ProtosLen = usize;
-#[cfg(feature = "fips")]
+#[cfg(feature = "fips-compat")]
 type ProtosLen = libc::c_uint;
 
 /// Information about the state of a cipher.
@@ -2883,7 +2883,7 @@ impl SslRef {
     /// Note: This is gated to non-fips because the fips feature builds with a separate
     /// version of BoringSSL which doesn't yet include these APIs.
     /// Once the submoduled fips commit is upgraded, these gates can be removed.
-    #[cfg(not(feature = "fips"))]
+    #[cfg(not(feature = "fips-compat"))]
     pub fn set_permute_extensions(&mut self, enabled: bool) {
         unsafe { ffi::SSL_set_permute_extensions(self.as_ptr(), enabled as _) }
     }
@@ -2894,7 +2894,7 @@ impl SslRef {
     #[corresponds(SSL_set_alpn_protos)]
     pub fn set_alpn_protos(&mut self, protocols: &[u8]) -> Result<(), ErrorStack> {
         unsafe {
-            #[cfg_attr(not(feature = "fips"), allow(clippy::unnecessary_cast))]
+            #[cfg_attr(not(feature = "fips-compat"), allow(clippy::unnecessary_cast))]
             {
                 assert!(protocols.len() <= ProtosLen::MAX as usize);
             }

--- a/boring/src/x509/mod.rs
+++ b/boring/src/x509/mod.rs
@@ -981,9 +981,9 @@ impl X509NameBuilder {
     }
 }
 
-#[cfg(not(feature = "fips"))]
+#[cfg(not(feature = "fips-compat"))]
 type ValueLen = isize;
-#[cfg(feature = "fips")]
+#[cfg(feature = "fips-compat")]
 type ValueLen = i32;
 
 foreign_type_and_impl_send_sync! {

--- a/boring/src/x509/tests/trusted_first.rs
+++ b/boring/src/x509/tests/trusted_first.rs
@@ -15,7 +15,7 @@ fn test_verify_cert() {
 
     assert_eq!(Ok(()), verify(&leaf, &[&root1], &[&intermediate], |_| {}));
 
-    #[cfg(not(feature = "fips"))]
+    #[cfg(not(feature = "fips-compat"))]
     assert_eq!(
         Ok(()),
         verify(
@@ -26,7 +26,7 @@ fn test_verify_cert() {
         )
     );
 
-    #[cfg(feature = "fips")]
+    #[cfg(feature = "fips-compat")]
     assert_eq!(
         Err(X509VerifyError::CERT_HAS_EXPIRED),
         verify(


### PR DESCRIPTION
This adds a feature to build against a BoringSSL version compatible with the current boringssl-fips, but _without_ actually enabling the `fips` feature.

This can be useful to use with `fips-link-precompiled` while using a custom BoringSSL version based on the older FIPS branch.