### PR TITLE
(ci): brew link x86 toolchain for macos13 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,6 +313,8 @@ jobs:
       uses: actions/setup-go@v5
       with:
         go-version: '>=1.22.0'
+    - name: Install ${{ matrix.target }} toolchain
+      run: brew tap messense/macos-cross-toolchains && brew install ${{ matrix.target }} && brew link x86_64-unknown-linux-gnu
     - name: Install Clang-12
       uses: KyleMayes/install-llvm-action@v1
       with:
@@ -320,10 +322,7 @@ jobs:
         directory: ${{ runner.temp }}/llvm
     - name: Add clang++-12 link
       working-directory: ${{ runner.temp }}/llvm/bin
-      run: ln -s clang clang++-12
-    - name: Install ${{ matrix.target }} toolchain
-      # TODO(rmehra): find a better way to overwrite the python3 version without specifying version
-      run: brew tap messense/macos-cross-toolchains && brew install --overwrite python@3.12 && brew install ${{ matrix.target }}
+      run: ln -s clang++ clang++-12
     - name: Set BORING_BSSL_FIPS_COMPILER_EXTERNAL_TOOLCHAIN
       run: echo "BORING_BSSL_FIPS_COMPILER_EXTERNAL_TOOLCHAIN=$(brew --prefix ${{ matrix.target }})/toolchain" >> $GITHUB_ENV
       shell: bash


### PR DESCRIPTION
It seems we need to manually symlink the x86_64-unknown-linux-gnu
toolchain for the macos13 runner. Also, we don't need to overwrite the
python version anymore

Fixes https://github.com/cloudflare/boring/issues/285