### PR TITLE
Remove INVALID_CALL from mid-handshake error message

### DIFF
--- a/boring/src/ssl/error.rs
+++ b/boring/src/ssl/error.rs
@@ -1,4 +1,5 @@
 use crate::ffi;
+use crate::x509::X509VerifyError;
 use libc::c_int;
 use std::error;
 use std::error::Error as StdError;
@@ -206,7 +207,9 @@ fn fmt_mid_handshake_error(
     }
 
     match s.ssl().verify_result() {
-        Ok(()) => write!(f, "{}", prefix)?,
+        // INVALID_CALL is returned if no verification took place,
+        // such as before a cert is sent.
+        Ok(()) | Err(X509VerifyError::INVALID_CALL) => write!(f, "{}", prefix)?,
         Err(verify) => write!(f, "{}: cert verification failed - {}", prefix, verify)?,
     }
 


### PR DESCRIPTION
Mid-handshake errors that occur before certificate verification currently look like this:

```
TLS handshake failed: cert verification failed - Invalid certificate verification context [WRONG_VERSION_NUMBER]
```

Despite no certificate even being received yet, the error complains about a failed verification. The cause here is that `cert verification failed` is only omitted if the verification result is `OK`. The default in BoringSSL before verification runs is `INVALID_CALL`, however.

`INVALID_CALL` is set/returned in these places:
- https://github.com/google/boringssl/blob/44b3df6f03d85c901767250329c571db405122d5/src/ssl/internal.h#L3904
- https://github.com/google/boringssl/blob/44b3df6f03d85c901767250329c571db405122d5/src/ssl/ssl_session.cc#L396
- https://github.com/google/boringssl/blob/44b3df6f03d85c901767250329c571db405122d5/src/ssl/ssl_x509.cc#L713

It is not used anywhere else as a verification result code. To improve the error message, this commit adds `INVALID_CALL` as a verification result for which no additional error is dislayed.