### PR TITLE
Fix fips-compat build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,8 +256,10 @@ jobs:
     - name: Add clang++-12 link
       working-directory: ${{ runner.temp }}/llvm/bin
       run: ln -s clang clang++-12
-    - name: Run tests
+    - name: Run FIPS tests
       run: cargo test --features fips
+    - name: Check fips-compat
+      run: cargo check --features fips-compat --all-targets
     - name: Test boring-sys cargo publish (FIPS)
       # Running `cargo publish --dry-run` tests two things:
       #

--- a/boring/src/bio.rs
+++ b/boring/src/bio.rs
@@ -19,18 +19,19 @@ impl<'a> Drop for MemBioSlice<'a> {
 
 impl<'a> MemBioSlice<'a> {
     pub fn new(buf: &'a [u8]) -> Result<MemBioSlice<'a>, ErrorStack> {
-        #[cfg(not(feature = "fips-compat"))]
+        #[cfg(not(feature = "fips"))]
         type BufLen = isize;
-        #[cfg(feature = "fips-compat")]
+        #[cfg(feature = "fips")]
         type BufLen = libc::c_int;
 
         ffi::init();
 
         assert!(buf.len() <= BufLen::MAX as usize);
         let bio = unsafe {
+            #[allow(clippy::useless_conversion)]
             cvt_p(BIO_new_mem_buf(
                 buf.as_ptr() as *const _,
-                buf.len() as BufLen,
+                buf.len().try_into().unwrap(),
             ))?
         };
 

--- a/boring/src/ssl/test/mod.rs
+++ b/boring/src/ssl/test/mod.rs
@@ -21,7 +21,7 @@ use crate::ssl::{
 use crate::x509::verify::X509CheckFlags;
 use crate::x509::{X509Name, X509};
 
-#[cfg(not(feature = "fips"))]
+#[cfg(not(feature = "fips-compat"))]
 use super::CompliancePolicy;
 
 mod cert_verify;
@@ -987,7 +987,7 @@ fn test_get_ciphers() {
 }
 
 #[test]
-#[cfg(not(feature = "fips"))]
+#[cfg(not(feature = "fips-compat"))]
 fn test_set_compliance() {
     let mut ctx = SslContext::builder(SslMethod::tls()).unwrap();
     ctx.set_compliance_policy(CompliancePolicy::FIPS_202205)

--- a/boring/src/x509/mod.rs
+++ b/boring/src/x509/mod.rs
@@ -885,12 +885,13 @@ impl X509NameBuilder {
         unsafe {
             let field = CString::new(field).unwrap();
             assert!(value.len() <= ValueLen::MAX as usize);
+            #[allow(clippy::useless_conversion)]
             cvt(ffi::X509_NAME_add_entry_by_txt(
                 self.0.as_ptr(),
                 field.as_ptr() as *mut _,
                 ffi::MBSTRING_UTF8,
                 value.as_ptr(),
-                value.len() as ValueLen,
+                value.len().try_into().unwrap(),
                 -1,
                 0,
             ))
@@ -912,12 +913,13 @@ impl X509NameBuilder {
         unsafe {
             let field = CString::new(field).unwrap();
             assert!(value.len() <= ValueLen::MAX as usize);
+            #[allow(clippy::useless_conversion)]
             cvt(ffi::X509_NAME_add_entry_by_txt(
                 self.0.as_ptr(),
                 field.as_ptr() as *mut _,
                 ty.as_raw(),
                 value.as_ptr(),
-                value.len() as ValueLen,
+                value.len().try_into().unwrap(),
                 -1,
                 0,
             ))
@@ -933,12 +935,13 @@ impl X509NameBuilder {
     pub fn append_entry_by_nid(&mut self, field: Nid, value: &str) -> Result<(), ErrorStack> {
         unsafe {
             assert!(value.len() <= ValueLen::MAX as usize);
+            #[allow(clippy::useless_conversion)]
             cvt(ffi::X509_NAME_add_entry_by_NID(
                 self.0.as_ptr(),
                 field.as_raw(),
                 ffi::MBSTRING_UTF8,
                 value.as_ptr() as *mut _,
-                value.len() as ValueLen,
+                value.len().try_into().unwrap(),
                 -1,
                 0,
             ))
@@ -959,12 +962,13 @@ impl X509NameBuilder {
     ) -> Result<(), ErrorStack> {
         unsafe {
             assert!(value.len() <= ValueLen::MAX as usize);
+            #[allow(clippy::useless_conversion)]
             cvt(ffi::X509_NAME_add_entry_by_NID(
                 self.0.as_ptr(),
                 field.as_raw(),
                 ty.as_raw(),
                 value.as_ptr() as *mut _,
-                value.len() as ValueLen,
+                value.len().try_into().unwrap(),
                 -1,
                 0,
             ))
@@ -981,9 +985,9 @@ impl X509NameBuilder {
     }
 }
 
-#[cfg(not(feature = "fips-compat"))]
+#[cfg(not(feature = "fips"))]
 type ValueLen = isize;
-#[cfg(feature = "fips-compat")]
+#[cfg(feature = "fips")]
 type ValueLen = i32;
 
 foreign_type_and_impl_send_sync! {
@@ -1549,6 +1553,7 @@ impl GeneralName {
         let gn = GeneralName::from_ptr(cvt_p(ffi::GENERAL_NAME_new())?);
         (*gn.as_ptr()).type_ = type_;
         let s = cvt_p(ffi::ASN1_STRING_type_new(asn1_type.as_raw()))?;
+        #[allow(clippy::useless_conversion)]
         ffi::ASN1_STRING_set(s, value.as_ptr().cast(), value.len().try_into().unwrap());
 
         (*gn.as_ptr()).d.ptr = s.cast();


### PR DESCRIPTION
Because `fips` feature implies `fips-compat`, the negation needs to be `not(fips-compat)`. Except for the ABI changes, which change only with the `fips` feature.

Just to be safe, I've used `.try_into().unwrap()` in FFI instead of assert + casts. `try_into()` will be optimized out when it really doesn't matter.
