### PR TITLE
Refactor!: Introduce a Cargo feature for optional Hyper 0 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,5 +366,7 @@ jobs:
       name: Run `rpk,underscore-wildcards` tests
     - run: cargo test --features pq-experimental,rpk,underscore-wildcards
       name: Run `pq-experimental,rpk,underscore-wildcards` tests
-    - run: cargo test -p hyper-boring --features hyper1
+    - run: cargo test -p hyper-boring --features hyper1-runtime
       name: Run hyper 1.0 tests for hyper-boring
+    - run: cargo test -p hyper-boring --features hyper0-runtime
+      name: Run hyper 0. tests for hyper-boring

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,12 +37,12 @@ futures = "0.3"
 tokio = "1"
 anyhow = "1"
 antidote = "1.0.0"
-http = "1"
+http1 = { package = "http", version = "1" }
 http-body-util = "0.1.2"
-http_old = { package = "http", version = "0.2" }
-hyper = "1"
+http0 = { package = "http", version = "0.2" }
+hyper1 = { package = "hyper", version = "1" }
 hyper-util = "0.1.6"
-hyper_old = { package = "hyper", version = "0.14", default-features = false }
+hyper0 = { package = "hyper", version = "0.14", default-features = false }
 linked_hash_set = "0.1"
 once_cell = "1.0"
 openssl-macros = "0.1.1"

--- a/hyper-boring/Cargo.toml
+++ b/hyper-boring/Cargo.toml
@@ -15,9 +15,13 @@ features = ["pq-experimental"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-default = ["runtime"]
+default = ["runtime", "hyper1-runtime"]
 
-runtime = ["hyper_old/runtime", "dep:tower"]
+runtime = []
+# `hyper1` + `runtime`.
+hyper1-runtime = ["hyper1", "dep:tower"]
+# `hyper0` + `runtime`.
+hyper0-runtime = ["hyper0", "hyper0/runtime"]
 
 # Use a FIPS-validated version of boringssl.
 fips = ["tokio-boring/fips"]
@@ -28,16 +32,18 @@ fips-link-precompiled = ["tokio-boring/fips-link-precompiled"]
 # Enables experimental post-quantum crypto (https://blog.cloudflare.com/post-quantum-for-all/)
 pq-experimental = ["tokio-boring/pq-experimental"]
 
-# Enable Hyper 1 support
-hyper1 = ["dep:http", "dep:hyper", "dep:hyper-util", "dep:tower-service"]
+# Enable Hyper 1 support.
+hyper1 = ["dep:hyper1", "dep:http1", "dep:hyper-util", "dep:tower-service"]
+# Enable Hyper 0 support.
+hyper0 = ["dep:hyper0", "dep:http0"]
 
 [dependencies]
 antidote = { workspace = true }
-http = { workspace = true, optional = true }
-http_old = { workspace = true }
-hyper = { workspace = true, optional = true }
+http1 = { workspace = true, optional = true }
+http0 = { workspace = true, optional = true }
+hyper1 = { workspace = true, optional = true }
 hyper-util = { workspace = true, optional = true, features = ["client", "client-legacy"] }
-hyper_old = { workspace = true, features = ["client"] }
+hyper0 = { workspace = true, optional = true, features = ["client"] }
 linked_hash_set = { workspace = true }
 once_cell = { workspace = true }
 boring = { workspace = true }
@@ -51,8 +57,8 @@ tower-service = { workspace = true, optional = true }
 bytes = { workspace = true }
 http-body-util = { workspace = true }
 hyper-util = { workspace = true, features = ["http1", "http2", "service", "tokio"] }
-hyper = { workspace = true, features = ["server"] }
-hyper_old = { workspace = true, features = [ "full" ] }
+hyper1 = { workspace = true, features = ["server"] }
+hyper0 = { workspace = true, features = [ "full" ] }
 tokio = { workspace = true, features = [ "full" ] }
 tower = { workspace = true, features = ["util"] }
 futures = { workspace = true }

--- a/hyper-boring/src/lib.rs
+++ b/hyper-boring/src/lib.rs
@@ -11,12 +11,14 @@ use std::fmt;
 use tokio_boring::SslStream;
 
 mod cache;
-mod v0;
-/// Hyper 1 support.
+/// Hyper 0 support.
+#[cfg(feature = "hyper0")]
+pub mod v0;
 #[cfg(feature = "hyper1")]
-pub mod v1;
+mod v1;
 
-pub use self::v0::*;
+#[cfg(feature = "hyper1")]
+pub use self::v1::*;
 
 fn key_index() -> Result<Index<Ssl, SessionKey>, ErrorStack> {
     static IDX: OnceCell<Index<Ssl, SessionKey>> = OnceCell::new();

--- a/hyper-boring/src/v0.rs
+++ b/hyper-boring/src/v0.rs
@@ -6,11 +6,11 @@ use boring::ssl::{
     ConnectConfiguration, Ssl, SslConnector, SslConnectorBuilder, SslMethod, SslRef,
     SslSessionCacheMode,
 };
-use http_old::uri::Scheme;
-use hyper_old::client::connect::{Connected, Connection};
-use hyper_old::client::HttpConnector;
-use hyper_old::service::Service;
-use hyper_old::Uri;
+use http0::uri::Scheme;
+use hyper0::client::connect::{Connected, Connection};
+use hyper0::client::HttpConnector;
+use hyper0::service::Service;
+use hyper0::Uri;
 use std::error::Error;
 use std::future::Future;
 use std::net;

--- a/hyper-boring/src/v1.rs
+++ b/hyper-boring/src/v1.rs
@@ -6,9 +6,9 @@ use boring::ssl::{
     ConnectConfiguration, Ssl, SslConnector, SslConnectorBuilder, SslMethod, SslRef,
     SslSessionCacheMode,
 };
-use http::uri::Scheme;
-use http::Uri;
-use hyper::rt::{Read, ReadBufCursor, Write};
+use http1::uri::Scheme;
+use http1::Uri;
+use hyper1::rt::{Read, ReadBufCursor, Write};
 use hyper_util::client::legacy::connect::{Connected, Connection, HttpConnector};
 use hyper_util::rt::TokioIo;
 use std::error::Error;
@@ -20,9 +20,9 @@ use std::task::{Context, Poll};
 use std::{io, net};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::TcpStream;
-#[cfg(feature = "runtime")]
+#[cfg(all(feature = "runtime", feature = "hyper1-runtime"))]
 use tower::util::MapResponse;
-#[cfg(feature = "runtime")]
+#[cfg(all(feature = "runtime", feature = "hyper1-runtime"))]
 use tower::ServiceExt;
 use tower_layer::Layer;
 use tower_service::Service;
@@ -39,7 +39,7 @@ pub struct HttpsConnector<T> {
 pub type TokioHttpConnector =
     MapResponse<HttpConnector, fn(TokioIo<TcpStream>) -> TokioIo<TokioIo<TcpStream>>>;
 
-#[cfg(feature = "runtime")]
+#[cfg(all(feature = "runtime", feature = "hyper1-runtime"))]
 impl HttpsConnector<TokioHttpConnector> {
     /// Creates a a new `HttpsConnector` using default settings.
     ///

--- a/hyper-boring/tests/v0.rs
+++ b/hyper-boring/tests/v0.rs
@@ -1,10 +1,12 @@
+#![cfg(feature = "hyper0")]
+
 use boring::ssl::{SslAcceptor, SslConnector, SslFiletype, SslMethod};
 use futures::StreamExt;
-use hyper_boring::HttpsConnector;
-use hyper_old::client::HttpConnector;
-use hyper_old::server::conn::Http;
-use hyper_old::{service, Response};
-use hyper_old::{Body, Client};
+use hyper0::client::HttpConnector;
+use hyper0::server::conn::Http;
+use hyper0::{service, Response};
+use hyper0::{Body, Client};
+use hyper_boring::v0::HttpsConnector;
 use std::convert::Infallible;
 use std::{io, iter};
 use tokio::net::TcpListener;

--- a/hyper-boring/tests/v1.rs
+++ b/hyper-boring/tests/v1.rs
@@ -4,8 +4,8 @@ use boring::ssl::{SslAcceptor, SslConnector, SslFiletype, SslMethod};
 use bytes::Bytes;
 use futures::StreamExt;
 use http_body_util::{BodyStream, Empty};
-use hyper::{service, Response};
-use hyper_boring::v1::HttpsConnector;
+use hyper1::{service, Response};
+use hyper_boring::HttpsConnector;
 use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::client::legacy::Client;
 use hyper_util::rt::{TokioExecutor, TokioIo};
@@ -56,7 +56,7 @@ async fn localhost() {
                 Ok::<_, io::Error>(Response::new(<Empty<Bytes>>::new()))
             });
 
-            hyper::server::conn::http1::Builder::new()
+            hyper1::server::conn::http1::Builder::new()
                 .keep_alive(false)
                 .serve_connection(TokioIo::new(stream), service)
                 .await
@@ -127,7 +127,7 @@ async fn alpn_h2() {
             Ok::<_, io::Error>(Response::new(<Empty<Bytes>>::new()))
         });
 
-        hyper::server::conn::http2::Builder::new(TokioExecutor::new())
+        hyper1::server::conn::http2::Builder::new(TokioExecutor::new())
             .serve_connection(TokioIo::new(stream), service)
             .await
             .unwrap();


### PR DESCRIPTION
Closes #294. Requires breaking changes, but only regarding the `hyper1` feature's enabled module path; the default v0 is still preserved. What is proposed here in order to achieve the objective is to have both modules be re-exported when the other feature is not enabled, and have them be made public when both features are enabled at the same time. This way, the features should be kept additive: all four combinations are supported. It enables dependency de-duplication when consuming it.