### PR TITLE
Refactor!: Remove strict `TokioIo` response requirement from `hyper_boring::v1::HttpsConnector`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ hyper_old = { package = "hyper", version = "0.14", default-features = false }
 linked_hash_set = "0.1"
 once_cell = "1.0"
 openssl-macros = "0.1.1"
-tower = "0.4"
+tower = { version = "0.4", default-features = false, features = ["util"] }
 tower-layer = "0.3"
 tower-service = "0.3"
 autocfg = "1.3.0"

--- a/hyper-boring/Cargo.toml
+++ b/hyper-boring/Cargo.toml
@@ -17,7 +17,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [features]
 default = ["runtime"]
 
-runtime = ["hyper_old/runtime"]
+runtime = ["hyper_old/runtime", "dep:tower"]
 
 # Use a FIPS-validated version of boringssl.
 fips = ["tokio-boring/fips"]
@@ -43,6 +43,7 @@ once_cell = { workspace = true }
 boring = { workspace = true }
 tokio = { workspace = true }
 tokio-boring = { workspace = true }
+tower = { workspace = true, optional = true }
 tower-layer = { workspace = true }
 tower-service = { workspace = true, optional = true }
 

--- a/hyper-boring/tests/v1.rs
+++ b/hyper-boring/tests/v1.rs
@@ -12,6 +12,7 @@ use hyper_util::rt::{TokioExecutor, TokioIo};
 use std::convert::Infallible;
 use std::{io, iter};
 use tokio::net::TcpListener;
+use tower::ServiceExt;
 
 #[tokio::test]
 async fn google() {
@@ -83,7 +84,7 @@ async fn localhost() {
         let _ = writeln!(&file, "{}", line);
     });
 
-    let ssl = HttpsConnector::with_connector(connector, ssl).unwrap();
+    let ssl = HttpsConnector::with_connector(connector.map_response(TokioIo::new), ssl).unwrap();
     let client = Client::builder(TokioExecutor::new()).build::<_, Empty<Bytes>>(ssl);
 
     for _ in 0..3 {
@@ -144,7 +145,8 @@ async fn alpn_h2() {
 
     ssl.set_ca_file("tests/test/root-ca.pem").unwrap();
 
-    let mut ssl = HttpsConnector::with_connector(connector, ssl).unwrap();
+    let mut ssl =
+        HttpsConnector::with_connector(connector.map_response(TokioIo::new), ssl).unwrap();
 
     ssl.set_ssl_callback(|ssl, _| ssl.set_alpn_protos(b"\x02h2\x08http/1.1"));
 


### PR DESCRIPTION
Closes #295. Should probably follow after #304. Requires breaking changes as well.