### PR TITLE
Clean up boring_sys::init()

### DIFF
--- a/boring-sys/src/lib.rs
+++ b/boring-sys/src/lib.rs
@@ -48,18 +48,7 @@ pub const fn ERR_GET_REASON(l: c_uint) -> c_int {
 }
 
 pub fn init() {
-    use std::ptr;
-    use std::sync::Once;
-
-    // explicitly initialize to work around https://github.com/openssl/openssl/issues/3505
-    static INIT: Once = Once::new();
-
-    let init_options = OPENSSL_INIT_LOAD_SSL_STRINGS;
-
-    INIT.call_once(|| {
-        assert_eq!(
-            unsafe { OPENSSL_init_ssl(init_options.try_into().unwrap(), ptr::null_mut()) },
-            1
-        )
-    });
+    unsafe {
+        CRYPTO_library_init();
+    }
 }


### PR DESCRIPTION
We don't need the workaround that was initially introduced for a bug in openssl, and OPENSSL_init_ssl always calls into CRYPTO_library_init on boringssl, so just call it explicitly.