### PR TITLE
Bump cmake-rs to improve Mac OS build parallelism

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ tokio-boring = { version = "4.13.0", path = "./tokio-boring" }
 
 bindgen = { version = "0.70.1", default-features = false, features = ["runtime"] }
 bytes = "1"
-cmake = "0.1.18"
+cmake = "0.1.54"
 fs_extra = "1.3.0"
 fslock = "0.2"
 bitflags = "2.4"

--- a/boring-sys/build/main.rs
+++ b/boring-sys/build/main.rs
@@ -576,10 +576,6 @@ fn built_boring_source_path(config: &Config) -> &PathBuf {
 
         let mut cfg = get_boringssl_cmake_config(config);
 
-        if let Ok(threads) = std::thread::available_parallelism() {
-            cfg.env("CMAKE_BUILD_PARALLEL_LEVEL", threads.to_string());
-        }
-
         if config.features.fips {
             let (clang, clangxx) = verify_fips_clang_version();
             cfg.define("CMAKE_C_COMPILER", clang)


### PR DESCRIPTION
There's a bug on OSX that prevents the CMake jobserver from working properly, and so CMake defaults to a single-threaded build. It's not clear when this is actually going to get fixed, so recent versions of cmake-rs just disable the jobserver and have CMake fall back to the number of available cores:
https://github.com/rust-lang/cmake-rs/pull/229

This means we don't need e6833b0074086422b065edec2839ec9800c73885