### PR TITLE
Revert cmake bump (for now) as it is overly restrictive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ tokio-boring = { version = "4.14.0", path = "./tokio-boring" }
 
 bindgen = { version = "0.70.1", default-features = false, features = ["runtime"] }
 bytes = "1"
-cmake = "0.1.54"
+cmake = "0.1.18"
 fs_extra = "1.3.0"
 fslock = "0.2"
 bitflags = "2.4"

--- a/boring-sys/build/main.rs
+++ b/boring-sys/build/main.rs
@@ -576,6 +576,10 @@ fn built_boring_source_path(config: &Config) -> &PathBuf {
 
         let mut cfg = get_boringssl_cmake_config(config);
 
+        if let Ok(threads) = std::thread::available_parallelism() {
+            cfg.env("CMAKE_BUILD_PARALLEL_LEVEL", threads.to_string());
+        }
+
         if config.features.fips {
             let (clang, clangxx) = verify_fips_clang_version();
             cfg.define("CMAKE_C_COMPILER", clang)


### PR DESCRIPTION
Some users of boring have issues with newer versions of cmake. Because we have an alternative solution, we can hold off on the bump for now.