### PR TITLE
Add missing release notes entry

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,5 +1,6 @@
 
 4.15.0
+- 2025-02-27 Expose API to enable certificate compression. (#241)
 - 2025-02-23 Fix lifetimes in ssl::select_next_proto
 - 2025-02-23 Revert cmake bump (for now) as it is overly restrictive (#321)
 - 2025-02-21 Introduce a builder pattern for SslEchKeys + make set_ech_keys take a reference (#320)


### PR DESCRIPTION
v4.15.0 was tagged a few days ago but wasn't released until today, where a new commit made it to master and snuck into the publish. I updated the v4.15.0 tag to point to the right commit hash as well.