### PR TITLE
Update to actions/cache@v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         id: rust-version
         run: echo "::set-output name=version::$(rustc --version)"
       - name: Cache cargo index
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.cargo/registry/index
           key: index-${{ runner.os }}-${{ github.run_number }}
@@ -45,14 +45,14 @@ jobs:
       - name: Create lockfile
         run: cargo generate-lockfile
       - name: Cache cargo registry
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.cargo/registry/cache
           key: registry-${{ runner.os }}-${{ steps.rust-version.outputs.version }}-${{ hashFiles('Cargo.lock') }}
       - name: Fetch dependencies
         run: cargo fetch
       - name: Cache target directory
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: target
           key: clippy-target-${{ runner.os }}-${{ steps.rust-version.outputs.version }}-${{ hashFiles('Cargo.lock') }}


### PR DESCRIPTION
GitHub has [removed](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down) the actions/cache@v1 and actions/cache@v2 actions as of March 1st. CI runs after March 1st will now fail, as seen [here](https://github.com/signalapp/boring/actions/runs/13734955858/job/38417497855?pr=33). 

To fix CI, this just drops in the latest actions/cache@v4 in place of the existing actions/cache@v1. I ran a test of it against our fork and it passed [here](https://github.com/signalapp/boring/actions/runs/13768046827).