### PR TITLE
Add set_ticket_key_callback (SSL_CTX_set_tlsext_ticket_key_cb)

### DIFF
--- a/boring/src/hmac.rs
+++ b/boring/src/hmac.rs
@@ -14,11 +14,7 @@ impl HmacCtxRef {
     /// Configures HmacCtx to use `md` as the hash function and `key` as the key.
     ///
     /// https://commondatastorage.googleapis.com/chromium-boringssl-docs/hmac.h.html#HMAC_Init_ex
-    ///
-    /// # Safety
-    ///
-    /// The caller must ensure HMAC_CTX has been initalized.
-    pub unsafe fn init(&mut self, key: &[u8], md: &MessageDigest) -> Result<(), ErrorStack> {
+    pub fn init(&mut self, key: &[u8], md: &MessageDigest) -> Result<(), ErrorStack> {
         ffi::init();
 
         unsafe {

--- a/boring/src/hmac.rs
+++ b/boring/src/hmac.rs
@@ -1,9 +1,7 @@
 use crate::cvt;
 use crate::error::ErrorStack;
+use crate::foreign_types::ForeignTypeRef;
 use crate::hash::MessageDigest;
-use std::ffi::c_void;
-
-use foreign_types::ForeignType;
 
 foreign_type_and_impl_send_sync! {
     type CType = ffi::HMAC_CTX;
@@ -12,7 +10,7 @@ foreign_type_and_impl_send_sync! {
     pub struct HmacCtx;
 }
 
-impl HmacCtx {
+impl HmacCtxRef {
     /// Configures HmacCtx to use `md` as the hash function and `key` as the key.
     ///
     /// https://commondatastorage.googleapis.com/chromium-boringssl-docs/hmac.h.html#HMAC_Init_ex
@@ -26,7 +24,7 @@ impl HmacCtx {
         unsafe {
             cvt(ffi::HMAC_Init_ex(
                 self.as_ptr(),
-                key.as_ptr() as *const c_void,
+                key.as_ptr().cast(),
                 key.len(),
                 md.as_ptr(),
                 // ENGINE api is deprecated

--- a/boring/src/hmac.rs
+++ b/boring/src/hmac.rs
@@ -1,0 +1,38 @@
+use crate::cvt;
+use crate::error::ErrorStack;
+use crate::hash::MessageDigest;
+use std::ffi::c_void;
+
+use foreign_types::ForeignType;
+
+foreign_type_and_impl_send_sync! {
+    type CType = ffi::HMAC_CTX;
+    fn drop = ffi::HMAC_CTX_free;
+
+    pub struct HmacCtx;
+}
+
+impl HmacCtx {
+    /// Configures HmacCtx to use `md` as the hash function and `key` as the key.
+    ///
+    /// https://commondatastorage.googleapis.com/chromium-boringssl-docs/hmac.h.html#HMAC_Init_ex
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure HMAC_CTX has been initalized.
+    pub unsafe fn init(&mut self, key: &[u8], md: &MessageDigest) -> Result<(), ErrorStack> {
+        ffi::init();
+
+        unsafe {
+            cvt(ffi::HMAC_Init_ex(
+                self.as_ptr(),
+                key.as_ptr() as *const c_void,
+                key.len(),
+                md.as_ptr(),
+                // ENGINE api is deprecated
+                core::ptr::null_mut(),
+            ))
+            .map(|_| ())
+        }
+    }
+}

--- a/boring/src/lib.rs
+++ b/boring/src/lib.rs
@@ -137,6 +137,7 @@ pub mod error;
 pub mod ex_data;
 pub mod fips;
 pub mod hash;
+pub mod hmac;
 pub mod hpke;
 pub mod memcmp;
 pub mod nid;

--- a/boring/src/ssl/callbacks.rs
+++ b/boring/src/ssl/callbacks.rs
@@ -299,7 +299,7 @@ where
         .ex_data::<F>(SslContext::cached_ex_index::<F>())
         .expect("expected session resumption callback");
 
-    // Safety: the callback guarantees that key_name is 16 bytes
+    // SAFETY: the callback guarantees that key_name is 16 bytes
     let key_name =
         unsafe { slice::from_raw_parts_mut(key_name, ffi::SSL_TICKET_KEY_NAME_LEN as usize) };
     let key_name = <&mut [u8; 16]>::try_from(key_name).expect("boring provides a 16-byte key name");

--- a/boring/src/ssl/mod.rs
+++ b/boring/src/ssl/mod.rs
@@ -1240,13 +1240,20 @@ impl SslContextBuilder {
     /// # Panics
     ///
     /// This method panics if this `Ssl` is associated with a RPK context.
+    ///
+    /// # Safety
+    ///
+    /// The application is responsible for correctly setting the key_name, iv, encryption context
+    /// and hmac context. See the [`SSL_CTX_set_tlsext_ticket_key_cb`] docs for additional info.
+    ///
+    /// [`SSL_CTX_set_tlsext_ticket_key_cb`]: https://commondatastorage.googleapis.com/chromium-boringssl-docs/ssl.h.html#SSL_CTX_set_tlsext_ticket_key_cb
     #[corresponds(SSL_CTX_set_tlsext_ticket_key_cb)]
-    pub fn set_ticket_key_callback<F>(&mut self, callback: F)
+    pub unsafe fn set_ticket_key_callback_unsafe<F>(&mut self, callback: F)
     where
         F: Fn(
                 &SslRef,
                 &mut [u8; 16],
-                *mut u8,
+                &mut [u8; ffi::EVP_MAX_IV_LENGTH as usize],
                 *mut ffi::EVP_CIPHER_CTX,
                 *mut ffi::HMAC_CTX,
                 bool,

--- a/boring/src/ssl/mod.rs
+++ b/boring/src/ssl/mod.rs
@@ -896,11 +896,12 @@ pub enum TicketKeyCallbackResult {
 
     /// Continue with a full handshake.
     ///
-    /// The peer supplied session ticket was not recognized.
+    /// When in decryption mode, this indicates that the peer supplied session ticket was not
+    /// recognized. When in encryption mode, this instructs boring to not send a session ticket.
     ///
     /// # Note
     ///
-    /// This is a decryption specific status code.
+    /// This is a decryption specific status code when using the submoduled BoringSSL.
     Noop,
 
     /// Resumption callback was successful.

--- a/boring/src/ssl/mod.rs
+++ b/boring/src/ssl/mod.rs
@@ -81,7 +81,7 @@ use crate::dh::DhRef;
 use crate::ec::EcKeyRef;
 use crate::error::ErrorStack;
 use crate::ex_data::Index;
-use crate::hmac::HmacCtx;
+use crate::hmac::HmacCtxRef;
 use crate::nid::Nid;
 use crate::pkey::{HasPrivate, PKeyRef, Params, Private};
 use crate::srtp::{SrtpProtectionProfile, SrtpProtectionProfileRef};
@@ -89,7 +89,7 @@ use crate::ssl::bio::BioMethod;
 use crate::ssl::callbacks::*;
 use crate::ssl::error::InnerError;
 use crate::stack::{Stack, StackRef, Stackable};
-use crate::symm::CipherCtx;
+use crate::symm::CipherCtxRef;
 use crate::x509::store::{X509Store, X509StoreBuilder, X509StoreBuilderRef, X509StoreRef};
 use crate::x509::verify::X509VerifyParamRef;
 use crate::x509::{
@@ -1258,8 +1258,8 @@ impl SslContextBuilder {
                 &SslRef,
                 &mut [u8; 16],
                 &mut [u8; ffi::EVP_MAX_IV_LENGTH as usize],
-                &mut CipherCtx,
-                &mut HmacCtx,
+                &mut CipherCtxRef,
+                &mut HmacCtxRef,
                 bool,
             ) -> TicketKeyCallbackResult
             + 'static

--- a/boring/src/ssl/mod.rs
+++ b/boring/src/ssl/mod.rs
@@ -888,6 +888,50 @@ pub enum SslInfoCallbackValue {
     Alert(SslInfoCallbackAlert),
 }
 
+/// Ticket key callback status.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum TicketKeyCallbackResult {
+    /// Abort the handshake.
+    Error,
+
+    /// The peer supplied session ticket was not recognized. Continue with a full handshake.
+    ///
+    /// # Note
+    ///
+    /// This is a decryption specific status code.
+    DecryptTicketUnrecognized,
+
+    /// Resumption callback was successful.
+    ///
+    /// When in decryption mode, attempt an abbreviated handshake via session resumption. When in
+    /// encryption mode, provide a new ticket to the client.
+    Success,
+
+    /// Resumption callback was successful. Attempt an abbreviated handshake, and additionally
+    /// provide new session tickets to the peer.
+    ///
+    /// Session resumption short-circuits some security checks of a full-handshake, in exchange for
+    /// potential performance gains. For this reason, a session ticket should only be valid for a
+    /// limited time. Providing the peer with renewed session tickets allows them to continue
+    /// session resumption with the new tickets.
+    ///
+    /// # Note
+    ///
+    /// This is a decryption specific status code.
+    DecryptSuccessRenew,
+}
+
+impl From<TicketKeyCallbackResult> for c_int {
+    fn from(value: TicketKeyCallbackResult) -> Self {
+        match value {
+            TicketKeyCallbackResult::Error => -1,
+            TicketKeyCallbackResult::DecryptTicketUnrecognized => 0,
+            TicketKeyCallbackResult::Success => 1,
+            TicketKeyCallbackResult::DecryptSuccessRenew => 2,
+        }
+    }
+}
+
 #[derive(Hash, Copy, Clone, PartialOrd, Ord, Eq, PartialEq, Debug)]
 pub struct SslInfoCallbackAlert(c_int);
 
@@ -1178,6 +1222,43 @@ impl SslContextBuilder {
             ffi::SSL_CTX_set_tlsext_servername_arg(self.as_ptr(), arg);
             ffi::SSL_CTX_set_tlsext_servername_callback(self.as_ptr(), Some(raw_sni::<F>));
         }
+    }
+
+    /// Configures a custom session ticket key callback for session resumption.
+    ///
+    /// Session Resumption uses the security context (aka. session tickets) of a previous
+    /// connection to establish a new connection via an abbreviated handshake. Skipping portions of
+    /// a handshake can potentially yield performance gains.
+    ///
+    /// An attacker that compromises a server's session ticket key can impersonate the server and,
+    /// prior to TLS 1.3, retroactively decrypt all application traffic from sessions using that
+    /// ticket key. Thus ticket keys must be regularly rotated for forward secrecy.
+    ///
+    /// # Panics
+    ///
+    /// This method panics if this `Ssl` is associated with a RPK context.
+    #[corresponds(SSL_CTX_set_tlsext_ticket_key_cb)]
+    pub fn set_ticket_key_callback<F>(&mut self, callback: F)
+    where
+        F: Fn(
+                &SslRef,
+                &mut [u8; 16],
+                *mut u8,
+                *mut ffi::EVP_CIPHER_CTX,
+                *mut ffi::HMAC_CTX,
+                bool,
+            ) -> TicketKeyCallbackResult
+            + 'static
+            + Sync
+            + Send,
+    {
+        #[cfg(feature = "rpk")]
+        assert!(!self.is_rpk, "This API is not supported for RPK");
+
+        unsafe {
+            self.replace_ex_data(SslContext::cached_ex_index::<F>(), callback);
+            ffi::SSL_CTX_set_tlsext_ticket_key_cb(self.as_ptr(), Some(raw_ticket_key::<F>))
+        };
     }
 
     /// Sets the certificate verification depth.

--- a/boring/src/ssl/mod.rs
+++ b/boring/src/ssl/mod.rs
@@ -81,6 +81,7 @@ use crate::dh::DhRef;
 use crate::ec::EcKeyRef;
 use crate::error::ErrorStack;
 use crate::ex_data::Index;
+use crate::hmac::HmacCtx;
 use crate::nid::Nid;
 use crate::pkey::{HasPrivate, PKeyRef, Params, Private};
 use crate::srtp::{SrtpProtectionProfile, SrtpProtectionProfileRef};
@@ -88,6 +89,7 @@ use crate::ssl::bio::BioMethod;
 use crate::ssl::callbacks::*;
 use crate::ssl::error::InnerError;
 use crate::stack::{Stack, StackRef, Stackable};
+use crate::symm::CipherCtx;
 use crate::x509::store::{X509Store, X509StoreBuilder, X509StoreBuilderRef, X509StoreRef};
 use crate::x509::verify::X509VerifyParamRef;
 use crate::x509::{
@@ -1237,6 +1239,8 @@ impl SslContextBuilder {
     /// prior to TLS 1.3, retroactively decrypt all application traffic from sessions using that
     /// ticket key. Thus ticket keys must be regularly rotated for forward secrecy.
     ///
+    /// CipherCtx and HmacCtx are guaranteed to be initialized.
+    ///
     /// # Panics
     ///
     /// This method panics if this `Ssl` is associated with a RPK context.
@@ -1248,14 +1252,14 @@ impl SslContextBuilder {
     ///
     /// [`SSL_CTX_set_tlsext_ticket_key_cb`]: https://commondatastorage.googleapis.com/chromium-boringssl-docs/ssl.h.html#SSL_CTX_set_tlsext_ticket_key_cb
     #[corresponds(SSL_CTX_set_tlsext_ticket_key_cb)]
-    pub unsafe fn set_ticket_key_callback_unsafe<F>(&mut self, callback: F)
+    pub unsafe fn set_ticket_key_callback<F>(&mut self, callback: F)
     where
         F: Fn(
                 &SslRef,
                 &mut [u8; 16],
                 &mut [u8; ffi::EVP_MAX_IV_LENGTH as usize],
-                *mut ffi::EVP_CIPHER_CTX,
-                *mut ffi::HMAC_CTX,
+                &mut CipherCtx,
+                &mut HmacCtx,
                 bool,
             ) -> TicketKeyCallbackResult
             + 'static

--- a/boring/src/ssl/mod.rs
+++ b/boring/src/ssl/mod.rs
@@ -894,12 +894,14 @@ pub enum TicketKeyCallbackResult {
     /// Abort the handshake.
     Error,
 
-    /// The peer supplied session ticket was not recognized. Continue with a full handshake.
+    /// Continue with a full handshake.
+    ///
+    /// The peer supplied session ticket was not recognized.
     ///
     /// # Note
     ///
     /// This is a decryption specific status code.
-    DecryptTicketUnrecognized,
+    Noop,
 
     /// Resumption callback was successful.
     ///
@@ -925,7 +927,7 @@ impl From<TicketKeyCallbackResult> for c_int {
     fn from(value: TicketKeyCallbackResult) -> Self {
         match value {
             TicketKeyCallbackResult::Error => -1,
-            TicketKeyCallbackResult::DecryptTicketUnrecognized => 0,
+            TicketKeyCallbackResult::Noop => 0,
             TicketKeyCallbackResult::Success => 1,
             TicketKeyCallbackResult::DecryptSuccessRenew => 2,
         }

--- a/boring/src/ssl/test/mod.rs
+++ b/boring/src/ssl/test/mod.rs
@@ -31,6 +31,7 @@ mod ech;
 mod private_key_method;
 mod server;
 mod session;
+mod session_resumption;
 mod verify;
 
 static ROOT_CERT: &[u8] = include_bytes!("../../../test/root-ca.pem");

--- a/boring/src/ssl/test/session_resumption.rs
+++ b/boring/src/ssl/test/session_resumption.rs
@@ -44,7 +44,7 @@ fn resume_session() {
     // Attempt to resume the connection using the session ticket
     let client_2 = server.client();
     let mut ssl_builder = client_2.build().builder();
-    unsafe { ssl_builder.ssl().set_session(&session_ticket).unwrap() };
+    unsafe { ssl_builder.ssl().set_session(session_ticket).unwrap() };
     let ssl_stream_2 = ssl_builder.connect();
 
     assert!(ssl_stream_2.ssl().session_reused());
@@ -85,7 +85,7 @@ fn custom_callback_success() {
     // Attempt to resume the connection using the session ticket
     let client_2 = server.client();
     let mut ssl_builder = client_2.build().builder();
-    unsafe { ssl_builder.ssl().set_session(&session_ticket).unwrap() };
+    unsafe { ssl_builder.ssl().set_session(session_ticket).unwrap() };
     let ssl_stream_2 = ssl_builder.connect();
 
     assert!(ssl_stream_2.ssl().session_reused());
@@ -128,7 +128,7 @@ fn custom_callback_unrecognized_decryption_ticket() {
     // Attempt to resume the connection using the session ticket
     let client_2 = server.client();
     let mut ssl_builder = client_2.build().builder();
-    unsafe { ssl_builder.ssl().set_session(&session_ticket).unwrap() };
+    unsafe { ssl_builder.ssl().set_session(session_ticket).unwrap() };
     let ssl_stream_2 = ssl_builder.connect();
 
     // Second connection was NOT resumed due to TicketKeyCallbackResult::Noop on decryption

--- a/boring/src/ssl/test/session_resumption.rs
+++ b/boring/src/ssl/test/session_resumption.rs
@@ -9,8 +9,10 @@ use std::ffi::c_void;
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::OnceLock;
 
-static CUSTOM_ENCRYPTION_CALLED_BACK: AtomicU8 = AtomicU8::new(0);
-static CUSTOM_DECRYPTION_CALLED_BACK: AtomicU8 = AtomicU8::new(0);
+static SUCCESS_ENCRYPTION_CALLED_BACK: AtomicU8 = AtomicU8::new(0);
+static SUCCESS_DECRYPTION_CALLED_BACK: AtomicU8 = AtomicU8::new(0);
+static NOOP_ENCRYPTION_CALLED_BACK: AtomicU8 = AtomicU8::new(0);
+static NOOP_DECRYPTION_CALLED_BACK: AtomicU8 = AtomicU8::new(0);
 
 #[test]
 fn resume_session() {
@@ -51,7 +53,7 @@ fn resume_session() {
 }
 
 #[test]
-fn custom_callback() {
+fn custom_callback_success() {
     static SESSION_TICKET: OnceLock<Vec<u8>> = OnceLock::new();
     static NST_RECIEVED_COUNT: AtomicU8 = AtomicU8::new(0);
 
@@ -59,7 +61,7 @@ fn custom_callback() {
     server.expected_connections_count(2);
     server
         .ctx()
-        .set_ticket_key_callback(test_tickey_key_callback);
+        .set_ticket_key_callback(test_success_tickey_key_callback);
     let server = server.build();
 
     let mut client = server.client();
@@ -77,8 +79,8 @@ fn custom_callback() {
 
     assert!(!ssl_stream.ssl().session_reused());
     assert!(SESSION_TICKET.get().is_some());
-    assert_eq!(CUSTOM_ENCRYPTION_CALLED_BACK.load(Ordering::SeqCst), 2);
-    assert_eq!(CUSTOM_DECRYPTION_CALLED_BACK.load(Ordering::SeqCst), 0);
+    assert_eq!(SUCCESS_ENCRYPTION_CALLED_BACK.load(Ordering::SeqCst), 2);
+    assert_eq!(SUCCESS_DECRYPTION_CALLED_BACK.load(Ordering::SeqCst), 0);
     assert_eq!(NST_RECIEVED_COUNT.load(Ordering::SeqCst), 2);
 
     // Retrieve the session ticket
@@ -91,12 +93,59 @@ fn custom_callback() {
     let ssl_stream_2 = ssl_builder.connect();
 
     assert!(ssl_stream_2.ssl().session_reused());
-    assert_eq!(CUSTOM_ENCRYPTION_CALLED_BACK.load(Ordering::SeqCst), 4);
-    assert_eq!(CUSTOM_DECRYPTION_CALLED_BACK.load(Ordering::SeqCst), 1);
+    assert_eq!(SUCCESS_ENCRYPTION_CALLED_BACK.load(Ordering::SeqCst), 4);
+    assert_eq!(SUCCESS_DECRYPTION_CALLED_BACK.load(Ordering::SeqCst), 1);
 }
 
-// Custom callback to encrypt and decrypt session tickets
-fn test_tickey_key_callback(
+#[test]
+fn custom_callback_unrecognized_decryption_ticket() {
+    static SESSION_TICKET: OnceLock<Vec<u8>> = OnceLock::new();
+    static NST_RECIEVED_COUNT: AtomicU8 = AtomicU8::new(0);
+
+    let mut server = Server::builder();
+    server.expected_connections_count(2);
+    server
+        .ctx()
+        .set_ticket_key_callback(test_noop_tickey_key_callback);
+    let server = server.build();
+
+    let mut client = server.client();
+    client
+        .ctx()
+        .set_session_cache_mode(SslSessionCacheMode::CLIENT);
+    client.ctx().set_new_session_callback(|_, session| {
+        NST_RECIEVED_COUNT.fetch_add(1, Ordering::SeqCst);
+        // The server sends multiple session tickets but we only care to retrieve one.
+        if SESSION_TICKET.get().is_none() {
+            SESSION_TICKET.set(session.to_der().unwrap()).unwrap();
+        }
+    });
+    let ssl_stream = client.connect();
+
+    assert!(!ssl_stream.ssl().session_reused());
+    assert!(SESSION_TICKET.get().is_some());
+    assert_eq!(NOOP_ENCRYPTION_CALLED_BACK.load(Ordering::SeqCst), 2);
+    assert_eq!(NOOP_DECRYPTION_CALLED_BACK.load(Ordering::SeqCst), 0);
+    assert_eq!(NST_RECIEVED_COUNT.load(Ordering::SeqCst), 2);
+
+    // Retrieve the session ticket
+    let session_ticket = SslSession::from_der(SESSION_TICKET.get().unwrap()).unwrap();
+
+    // Attempt to resume the connection using the session ticket
+    let client_2 = server.client();
+    let mut ssl_builder = client_2.build().builder();
+    unsafe { ssl_builder.ssl().set_session(&session_ticket).unwrap() };
+    let ssl_stream_2 = ssl_builder.connect();
+
+    // Second connection was NOT resumed due to TicketKeyCallbackResult::Noop on decryption
+    assert!(!ssl_stream_2.ssl().session_reused());
+    assert_eq!(NOOP_ENCRYPTION_CALLED_BACK.load(Ordering::SeqCst), 4);
+    assert_eq!(NOOP_DECRYPTION_CALLED_BACK.load(Ordering::SeqCst), 1);
+}
+
+// Successfully return a session ticket in encryption mode but return a
+// TicketKeyCallbackResult::Noop in decryption mode.
+fn test_noop_tickey_key_callback(
     _ssl: &SslRef,
     _key_name: &mut [u8; 16],
     _iv: *mut u8,
@@ -113,7 +162,59 @@ fn test_tickey_key_callback(
     let cipher = Cipher::aes_128_cbc();
 
     if encrypt {
-        CUSTOM_ENCRYPTION_CALLED_BACK.fetch_add(1, Ordering::SeqCst);
+        NOOP_ENCRYPTION_CALLED_BACK.fetch_add(1, Ordering::SeqCst);
+        // Set the encryption context.
+        let ret = unsafe {
+            ffi::EVP_EncryptInit_ex(
+                evp_ctx,
+                cipher.as_ptr(),
+                // ENGINE api is deprecated
+                core::ptr::null_mut(),
+                TEST_AES_128_CBC_KEY.as_ptr(),
+                TEST_CBC_IV.as_ptr(),
+            )
+        };
+        assert!(ret == 1);
+
+        // Set the hmac context.
+        let ret = unsafe {
+            ffi::HMAC_Init_ex(
+                hmac_ctx,
+                TEST_HMAC_KEY.as_ptr() as *const c_void,
+                TEST_HMAC_KEY.len(),
+                digest.as_ptr(),
+                // ENGINE api is deprecated
+                core::ptr::null_mut(),
+            )
+        };
+        assert!(ret == 1);
+
+        TicketKeyCallbackResult::Success
+    } else {
+        NOOP_DECRYPTION_CALLED_BACK.fetch_add(1, Ordering::SeqCst);
+        TicketKeyCallbackResult::Noop
+    }
+}
+
+// Custom callback to encrypt and decrypt session tickets
+fn test_success_tickey_key_callback(
+    _ssl: &SslRef,
+    _key_name: &mut [u8; 16],
+    _iv: *mut u8,
+    evp_ctx: *mut ffi::EVP_CIPHER_CTX,
+    hmac_ctx: *mut ffi::HMAC_CTX,
+    encrypt: bool,
+) -> TicketKeyCallbackResult {
+    // These should only be used for testing purposes.
+    const TEST_CBC_IV: [u8; 16] = [1; 16];
+    const TEST_AES_128_CBC_KEY: [u8; 16] = [2; 16];
+    const TEST_HMAC_KEY: [u8; 32] = [3; 32];
+
+    let digest = MessageDigest::sha256();
+    let cipher = Cipher::aes_128_cbc();
+
+    if encrypt {
+        SUCCESS_ENCRYPTION_CALLED_BACK.fetch_add(1, Ordering::SeqCst);
         // Set the encryption context.
         let ret = unsafe {
             ffi::EVP_EncryptInit_ex(
@@ -140,7 +241,7 @@ fn test_tickey_key_callback(
         };
         assert!(ret == 1);
     } else {
-        CUSTOM_DECRYPTION_CALLED_BACK.fetch_add(1, Ordering::SeqCst);
+        SUCCESS_DECRYPTION_CALLED_BACK.fetch_add(1, Ordering::SeqCst);
         let ret = unsafe {
             ffi::EVP_DecryptInit_ex(
                 evp_ctx,

--- a/boring/src/ssl/test/session_resumption.rs
+++ b/boring/src/ssl/test/session_resumption.rs
@@ -1,12 +1,12 @@
 use super::server::Server;
 use crate::ssl::test::MessageDigest;
-use crate::ssl::HmacCtx;
+use crate::ssl::HmacCtxRef;
 use crate::ssl::SslRef;
 use crate::ssl::SslSession;
 use crate::ssl::SslSessionCacheMode;
 use crate::ssl::TicketKeyCallbackResult;
 use crate::symm::Cipher;
-use crate::symm::CipherCtx;
+use crate::symm::CipherCtxRef;
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::OnceLock;
 
@@ -148,8 +148,8 @@ fn test_noop_tickey_key_callback(
     _ssl: &SslRef,
     key_name: &mut [u8; 16],
     iv: &mut [u8; ffi::EVP_MAX_IV_LENGTH as usize],
-    evp_ctx: &mut CipherCtx,
-    hmac_ctx: &mut HmacCtx,
+    evp_ctx: &mut CipherCtxRef,
+    hmac_ctx: &mut HmacCtxRef,
     encrypt: bool,
 ) -> TicketKeyCallbackResult {
     // These should only be used for testing purposes.
@@ -188,8 +188,8 @@ fn test_success_tickey_key_callback(
     _ssl: &SslRef,
     key_name: &mut [u8; 16],
     iv: &mut [u8; ffi::EVP_MAX_IV_LENGTH as usize],
-    evp_ctx: &mut CipherCtx,
-    hmac_ctx: &mut HmacCtx,
+    evp_ctx: &mut CipherCtxRef,
+    hmac_ctx: &mut HmacCtxRef,
     encrypt: bool,
 ) -> TicketKeyCallbackResult {
     // These should only be used for testing purposes.

--- a/boring/src/ssl/test/session_resumption.rs
+++ b/boring/src/ssl/test/session_resumption.rs
@@ -1,0 +1,159 @@
+use super::server::Server;
+use crate::ssl::test::MessageDigest;
+use crate::ssl::SslRef;
+use crate::ssl::SslSession;
+use crate::ssl::SslSessionCacheMode;
+use crate::ssl::TicketKeyCallbackResult;
+use crate::symm::Cipher;
+use std::ffi::c_void;
+use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::OnceLock;
+
+static CUSTOM_ENCRYPTION_CALLED_BACK: AtomicU8 = AtomicU8::new(0);
+static CUSTOM_DECRYPTION_CALLED_BACK: AtomicU8 = AtomicU8::new(0);
+
+#[test]
+fn resume_session() {
+    static SESSION_TICKET: OnceLock<Vec<u8>> = OnceLock::new();
+
+    let mut server = Server::builder();
+    server.expected_connections_count(2);
+    let server = server.build();
+
+    let mut client = server.client();
+    client
+        .ctx()
+        .set_session_cache_mode(SslSessionCacheMode::CLIENT);
+    client.ctx().set_new_session_callback(|_, session| {
+        let _can_receive_multiple_tickets = SESSION_TICKET.set(session.to_der().unwrap());
+    });
+    let ssl_stream = client.connect();
+
+    assert!(!ssl_stream.ssl().session_reused());
+    assert!(SESSION_TICKET.get().is_some());
+
+    // Retrieve the session ticket
+    let session_ticket = SslSession::from_der(SESSION_TICKET.get().unwrap()).unwrap();
+
+    // Attempt to resume the connection using the session ticket
+    let client_2 = server.client();
+    let mut ssl_builder = client_2.build().builder();
+    unsafe { ssl_builder.ssl().set_session(&session_ticket).unwrap() };
+    let ssl_stream_2 = ssl_builder.connect();
+
+    assert!(ssl_stream_2.ssl().session_reused());
+}
+
+#[test]
+fn custom_callback() {
+    static SESSION_TICKET: OnceLock<Vec<u8>> = OnceLock::new();
+
+    let mut server = Server::builder();
+    server.expected_connections_count(2);
+    server
+        .ctx()
+        .set_ticket_key_callback(test_tickey_key_callback);
+    let server = server.build();
+
+    let mut client = server.client();
+    client
+        .ctx()
+        .set_session_cache_mode(SslSessionCacheMode::CLIENT);
+    client.ctx().set_new_session_callback(|_, session| {
+        let _can_receive_multiple_tickets = SESSION_TICKET.set(session.to_der().unwrap());
+    });
+    let ssl_stream = client.connect();
+
+    assert!(!ssl_stream.ssl().session_reused());
+    assert!(SESSION_TICKET.get().is_some());
+    assert_eq!(CUSTOM_ENCRYPTION_CALLED_BACK.load(Ordering::SeqCst), 2);
+    assert_eq!(CUSTOM_DECRYPTION_CALLED_BACK.load(Ordering::SeqCst), 0);
+
+    // Retrieve the session ticket
+    let session_ticket = SslSession::from_der(SESSION_TICKET.get().unwrap()).unwrap();
+
+    // Attempt to resume the connection using the session ticket
+    let client_2 = server.client();
+    let mut ssl_builder = client_2.build().builder();
+    unsafe { ssl_builder.ssl().set_session(&session_ticket).unwrap() };
+    let ssl_stream_2 = ssl_builder.connect();
+
+    assert!(ssl_stream_2.ssl().session_reused());
+    assert_eq!(CUSTOM_ENCRYPTION_CALLED_BACK.load(Ordering::SeqCst), 4);
+    assert_eq!(CUSTOM_DECRYPTION_CALLED_BACK.load(Ordering::SeqCst), 1);
+}
+
+// Custom callback to encrypt and decrypt session tickets
+fn test_tickey_key_callback(
+    _ssl: &SslRef,
+    _key_name: &mut [u8; 16],
+    _iv: *mut u8,
+    evp_ctx: *mut ffi::EVP_CIPHER_CTX,
+    hmac_ctx: *mut ffi::HMAC_CTX,
+    encrypt: bool,
+) -> TicketKeyCallbackResult {
+    // These should only be used for testing purposes.
+    const TEST_CBC_IV: [u8; 16] = [1; 16];
+    const TEST_AES_128_CBC_KEY: [u8; 16] = [2; 16];
+    const TEST_HMAC_KEY: [u8; 32] = [3; 32];
+
+    let digest = MessageDigest::sha256();
+    let cipher = Cipher::aes_128_cbc();
+
+    if encrypt {
+        CUSTOM_ENCRYPTION_CALLED_BACK.fetch_add(1, Ordering::SeqCst);
+        // Set the encryption context.
+        let ret = unsafe {
+            ffi::EVP_EncryptInit_ex(
+                evp_ctx,
+                cipher.as_ptr(),
+                // ENGINE api is deprecated
+                core::ptr::null_mut(),
+                TEST_AES_128_CBC_KEY.as_ptr(),
+                TEST_CBC_IV.as_ptr(),
+            )
+        };
+        assert!(ret == 1);
+
+        // Set the hmac context.
+        let ret = unsafe {
+            ffi::HMAC_Init_ex(
+                hmac_ctx,
+                TEST_HMAC_KEY.as_ptr() as *const c_void,
+                TEST_HMAC_KEY.len(),
+                digest.as_ptr(),
+                // ENGINE api is deprecated
+                core::ptr::null_mut(),
+            )
+        };
+        assert!(ret == 1);
+    } else {
+        CUSTOM_DECRYPTION_CALLED_BACK.fetch_add(1, Ordering::SeqCst);
+        let ret = unsafe {
+            ffi::EVP_DecryptInit_ex(
+                evp_ctx,
+                cipher.as_ptr(),
+                // ENGINE api is deprecated
+                core::ptr::null_mut(),
+                TEST_AES_128_CBC_KEY.as_ptr(),
+                TEST_CBC_IV.as_ptr(),
+            )
+        };
+        assert!(ret == 1);
+
+        // Set the hmac context.
+        let ret = unsafe {
+            ffi::HMAC_Init_ex(
+                hmac_ctx,
+                TEST_HMAC_KEY.as_ptr() as *const c_void,
+                TEST_HMAC_KEY.len(),
+                digest.as_ptr(),
+                // ENGINE api is deprecated
+                core::ptr::null_mut(),
+            )
+        };
+        assert!(ret == 1);
+    }
+
+    TicketKeyCallbackResult::Success
+}

--- a/boring/src/symm.rs
+++ b/boring/src/symm.rs
@@ -80,20 +80,17 @@ impl CipherCtxRef {
     /// Configures CipherCtx for a fresh encryption operation using `cipher`.
     ///
     /// https://commondatastorage.googleapis.com/chromium-boringssl-docs/cipher.h.html#EVP_EncryptInit_ex
-    ///
-    /// # Safety
-    ///
-    /// The caller must ensure EVP_CIPHER_CTX has been initalized.
-    ///
-    /// The caller is responsible for ensuring the length of `key` and `iv` are appropriate for the
-    /// chosen Cipher.
-    pub unsafe fn init_encrypt(
+    pub fn init_encrypt(
         &mut self,
         cipher: &Cipher,
         key: &[u8],
         iv: &[u8; ffi::EVP_MAX_IV_LENGTH as usize],
     ) -> Result<(), ErrorStack> {
         ffi::init();
+
+        if key.len() != cipher.key_len() {
+            return Err(ErrorStack::get());
+        }
 
         unsafe {
             cvt(ffi::EVP_EncryptInit_ex(
@@ -111,20 +108,17 @@ impl CipherCtxRef {
     /// Configures CipherCtx for a fresh decryption operation using `cipher`.
     ///
     /// https://commondatastorage.googleapis.com/chromium-boringssl-docs/cipher.h.html#EVP_DecryptInit_ex
-    ///
-    /// # Safety
-    ///
-    /// The caller must ensure EVP_CIPHER_CTX has been initalized.
-    ///
-    /// The caller is responsible for ensuring the length of `key` and `iv` are appropriate for the
-    /// chosen Cipher.
-    pub unsafe fn init_decrypt(
+    pub fn init_decrypt(
         &mut self,
         cipher: &Cipher,
         key: &[u8],
         iv: &[u8; ffi::EVP_MAX_IV_LENGTH as usize],
     ) -> Result<(), ErrorStack> {
         ffi::init();
+
+        if key.len() != cipher.key_len() {
+            return Err(ErrorStack::get());
+        }
 
         unsafe {
             cvt(ffi::EVP_DecryptInit_ex(

--- a/boring/src/symm.rs
+++ b/boring/src/symm.rs
@@ -53,7 +53,7 @@
 //! ```
 
 use crate::ffi;
-use foreign_types::ForeignType;
+use foreign_types::ForeignTypeRef;
 use libc::{c_int, c_uint};
 use openssl_macros::corresponds;
 use std::cmp;
@@ -76,7 +76,7 @@ foreign_type_and_impl_send_sync! {
     pub struct CipherCtx;
 }
 
-impl CipherCtx {
+impl CipherCtxRef {
     /// Configures CipherCtx for a fresh encryption operation using `cipher`.
     ///
     /// https://commondatastorage.googleapis.com/chromium-boringssl-docs/cipher.h.html#EVP_EncryptInit_ex

--- a/boring/src/symm.rs
+++ b/boring/src/symm.rs
@@ -53,6 +53,7 @@
 //! ```
 
 use crate::ffi;
+use foreign_types::ForeignType;
 use libc::{c_int, c_uint};
 use openssl_macros::corresponds;
 use std::cmp;
@@ -66,6 +67,77 @@ use crate::{cvt, cvt_p};
 pub enum Mode {
     Encrypt,
     Decrypt,
+}
+
+foreign_type_and_impl_send_sync! {
+    type CType = ffi::EVP_CIPHER_CTX;
+    fn drop = ffi::EVP_CIPHER_CTX_free;
+
+    pub struct CipherCtx;
+}
+
+impl CipherCtx {
+    /// Configures CipherCtx for a fresh encryption operation using `cipher`.
+    ///
+    /// https://commondatastorage.googleapis.com/chromium-boringssl-docs/cipher.h.html#EVP_EncryptInit_ex
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure EVP_CIPHER_CTX has been initalized.
+    ///
+    /// The caller is responsible for ensuring the length of `key` and `iv` are appropriate for the
+    /// chosen Cipher.
+    pub unsafe fn init_encrypt(
+        &mut self,
+        cipher: &Cipher,
+        key: &[u8],
+        iv: &[u8; ffi::EVP_MAX_IV_LENGTH as usize],
+    ) -> Result<(), ErrorStack> {
+        ffi::init();
+
+        unsafe {
+            cvt(ffi::EVP_EncryptInit_ex(
+                self.as_ptr(),
+                cipher.as_ptr(),
+                // ENGINE api is deprecated
+                ptr::null_mut(),
+                key.as_ptr(),
+                iv.as_ptr(),
+            ))
+            .map(|_| ())
+        }
+    }
+
+    /// Configures CipherCtx for a fresh decryption operation using `cipher`.
+    ///
+    /// https://commondatastorage.googleapis.com/chromium-boringssl-docs/cipher.h.html#EVP_DecryptInit_ex
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure EVP_CIPHER_CTX has been initalized.
+    ///
+    /// The caller is responsible for ensuring the length of `key` and `iv` are appropriate for the
+    /// chosen Cipher.
+    pub unsafe fn init_decrypt(
+        &mut self,
+        cipher: &Cipher,
+        key: &[u8],
+        iv: &[u8; ffi::EVP_MAX_IV_LENGTH as usize],
+    ) -> Result<(), ErrorStack> {
+        ffi::init();
+
+        unsafe {
+            cvt(ffi::EVP_DecryptInit_ex(
+                self.as_ptr(),
+                cipher.as_ptr(),
+                // ENGINE api is deprecated
+                ptr::null_mut(),
+                key.as_ptr(),
+                iv.as_ptr(),
+            ))
+            .map(|_| ())
+        }
+    }
 }
 
 /// Represents a particular cipher algorithm.


### PR DESCRIPTION
Add a wrapper for the `SSL_CTX_set_tlsext_ticket_key_cb`, which allows consumers to configure the EVP_CIPHER_CTX and HMAC_CTX used for encrypting/decrypting session tickets.

See https://docs.openssl.org/1.0.2/man3/SSL_CTX_set_tlsext_ticket_key_cb/ for more details.