### PR TITLE
boring-sys: Ignore patches when boringSSL is precompiled

### DIFF
--- a/boring-sys/build/config.rs
+++ b/boring-sys/build/config.rs
@@ -96,10 +96,15 @@ impl Config {
             || self.features.underscore_wildcards;
 
         let patches_required = features_with_patches_enabled && !self.env.assume_patched;
-        let build_from_sources_required = self.features.fips_link_precompiled || patches_required;
 
-        if is_precompiled_native_lib && build_from_sources_required {
-            panic!("precompiled BoringSSL was provided, so FIPS configuration or optional patches can't be applied");
+        if is_precompiled_native_lib && patches_required {
+            println!(
+                "cargo:warning=precompiled BoringSSL was provided, so patches will be ignored"
+            );
+        }
+
+        if is_precompiled_native_lib && self.features.fips_link_precompiled {
+            panic!("precompiled BoringSSL was provided, so FIPS configuration can't be applied");
         }
     }
 }

--- a/boring/src/ssl/mod.rs
+++ b/boring/src/ssl/mod.rs
@@ -718,15 +718,15 @@ impl SslCurve {
     pub const X25519_KYBER768_DRAFT00: SslCurve =
         SslCurve(ffi::SSL_CURVE_X25519_KYBER768_DRAFT00 as _);
 
-    #[cfg(feature = "pq-experimental")]
+    #[cfg(all(not(feature = "fips"), feature = "pq-experimental"))]
     pub const X25519_KYBER768_DRAFT00_OLD: SslCurve =
         SslCurve(ffi::SSL_CURVE_X25519_KYBER768_DRAFT00_OLD as _);
 
-    #[cfg(feature = "pq-experimental")]
+    #[cfg(all(not(feature = "fips"), feature = "pq-experimental"))]
     pub const X25519_KYBER512_DRAFT00: SslCurve =
         SslCurve(ffi::SSL_CURVE_X25519_KYBER512_DRAFT00 as _);
 
-    #[cfg(feature = "pq-experimental")]
+    #[cfg(all(not(feature = "fips"), feature = "pq-experimental"))]
     pub const P256_KYBER768_DRAFT00: SslCurve = SslCurve(ffi::SSL_CURVE_P256_KYBER768_DRAFT00 as _);
 
     /// Returns the curve name
@@ -761,13 +761,13 @@ impl SslCurve {
             ffi::SSL_CURVE_X25519 => Some(ffi::NID_X25519),
             #[cfg(not(any(feature = "fips", feature = "fips-no-compat")))]
             ffi::SSL_CURVE_X25519_KYBER768_DRAFT00 => Some(ffi::NID_X25519Kyber768Draft00),
-            #[cfg(feature = "pq-experimental")]
+            #[cfg(all(not(feature = "fips"), feature = "pq-experimental"))]
             ffi::SSL_CURVE_X25519_KYBER768_DRAFT00_OLD => Some(ffi::NID_X25519Kyber768Draft00Old),
-            #[cfg(feature = "pq-experimental")]
+            #[cfg(all(not(feature = "fips"), feature = "pq-experimental"))]
             ffi::SSL_CURVE_X25519_KYBER512_DRAFT00 => Some(ffi::NID_X25519Kyber512Draft00),
-            #[cfg(feature = "pq-experimental")]
+            #[cfg(all(not(feature = "fips"), feature = "pq-experimental"))]
             ffi::SSL_CURVE_P256_KYBER768_DRAFT00 => Some(ffi::NID_P256Kyber768Draft00),
-            #[cfg(feature = "pq-experimental")]
+            #[cfg(all(not(feature = "fips"), feature = "pq-experimental"))]
             ffi::SSL_CURVE_X25519_MLKEM768 => Some(ffi::NID_X25519MLKEM768),
             _ => None,
         }


### PR DESCRIPTION
Internal users often have two builds for `boring`, one using a precompiled build of boringSSL and another built from source with patches applied. However the features that enable these builds are mutually exclusive. For example, the `"pq-experimental"` feature is required to build the source with all of the necessary codepoints for PQ key exchange, but if this feature is enabled and a precompiled boringSSL is provided, then the build will fail. This means users will have to also control their builds with mutually exclusive features.

An alternative is to *ignore* features that enable patches whenever a precompiled boringSSL is provided. This is a little different from the "assume patched" environment variable, which applies whenever we're building from source.