### PR TITLE
feat(x509): Implement `Clone` for `X509Store`

### DIFF
--- a/boring-sys/Cargo.toml
+++ b/boring-sys/Cargo.toml
@@ -18,6 +18,7 @@ include = [
     "/*.toml",
     "/LICENSE-MIT",
     "/cmake/*.cmake",
+    "/deps/boringssl/src/util/32-bit-toolchain.cmake",
     # boringssl (non-FIPS)
     "/deps/boringssl/**/*.[chS]",
     "/deps/boringssl/**/*.asm",

--- a/boring-sys/Cargo.toml
+++ b/boring-sys/Cargo.toml
@@ -18,8 +18,8 @@ include = [
     "/*.toml",
     "/LICENSE-MIT",
     "/cmake/*.cmake",
-    "/deps/boringssl/src/util/32-bit-toolchain.cmake",
     # boringssl (non-FIPS)
+    "/deps/boringssl/src/util/32-bit-toolchain.cmake",
     "/deps/boringssl/**/*.[chS]",
     "/deps/boringssl/**/*.asm",
     "/deps/boringssl/sources.json",
@@ -31,6 +31,7 @@ include = [
     "/deps/boringssl/**/sources.cmake",
     "/deps/boringssl/LICENSE",
     # boringssl (FIPS)
+    "/deps/boringssl-fips/src/util/32-bit-toolchain.cmake",
     "/deps/boringssl-fips/**/*.[chS]",
     "/deps/boringssl-fips/**/*.asm",
     "/deps/boringssl-fips/**/*.pl",

--- a/boring/src/x509/store.rs
+++ b/boring/src/x509/store.rs
@@ -125,6 +125,23 @@ foreign_type_and_impl_send_sync! {
     pub struct X509Store;
 }
 
+impl Clone for X509Store {
+    fn clone(&self) -> Self {
+        (**self).to_owned()
+    }
+}
+
+impl ToOwned for X509StoreRef {
+    type Owned = X509Store;
+
+    fn to_owned(&self) -> Self::Owned {
+        unsafe {
+            ffi::X509_STORE_up_ref(self.as_ptr());
+            X509Store::from_ptr(self.as_ptr())
+        }
+    }
+}
+
 impl X509StoreRef {
     /// **Warning: this method is unsound**
     ///


### PR DESCRIPTION
Some scenarios require repeatedly creating TLS connectors. We aim to reuse X509Store instead of recreating it each time. Implementing Clone could be a good solution.