### PR TITLE
Expose SSL_set1_groups to Efficiently Set Curves on SSL Session

### DIFF
--- a/boring/src/ssl/mod.rs
+++ b/boring/src/ssl/mod.rs
@@ -2858,7 +2858,7 @@ impl SslRef {
     #[corresponds(SSL_set1_groups)]
     pub fn set_group_nids(&mut self, group_nids: &[SslCurveNid]) -> Result<(), ErrorStack> {
         unsafe {
-            cvt_0i(ffi::SSL_set1_groups(
+            cvt_0i(ffi::SSL_set1_curves(
                 self.as_ptr(),
                 group_nids.as_ptr() as *const _,
                 group_nids.len(),

--- a/boring/src/ssl/mod.rs
+++ b/boring/src/ssl/mod.rs
@@ -698,6 +698,11 @@ impl From<u16> for SslSignatureAlgorithm {
     }
 }
 
+/// Numeric identifier of a TLS curve.
+#[repr(transparent)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct SslCurveNid(c_int);
+
 /// A TLS Curve.
 #[repr(transparent)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -767,7 +772,7 @@ impl SslCurve {
     // underlying boringssl version is upgraded, this should be removed in favor of the new
     // SSL_CTX_set1_group_ids API.
     #[allow(dead_code)]
-    pub fn nid(&self) -> Option<c_int> {
+    pub fn nid(&self) -> Option<SslCurveNid> {
         match self.0 {
             ffi::SSL_CURVE_SECP224R1 => Some(ffi::NID_secp224r1),
             ffi::SSL_CURVE_SECP256R1 => Some(ffi::NID_X9_62_prime256v1),
@@ -798,6 +803,7 @@ impl SslCurve {
             ffi::SSL_CURVE_X25519_MLKEM768 => Some(ffi::NID_X25519MLKEM768),
             _ => None,
         }
+        .map(SslCurveNid)
     }
 }
 
@@ -1999,7 +2005,10 @@ impl SslContextBuilder {
     #[corresponds(SSL_CTX_set1_curves)]
     #[cfg(not(feature = "kx-safe-default"))]
     pub fn set_curves(&mut self, curves: &[SslCurve]) -> Result<(), ErrorStack> {
-        let curves: Vec<i32> = curves.iter().filter_map(|curve| curve.nid()).collect();
+        let curves: Vec<i32> = curves
+            .iter()
+            .filter_map(|curve| curve.nid().map(|nid| nid.0))
+            .collect();
 
         unsafe {
             cvt_0i(ffi::SSL_CTX_set1_curves(
@@ -2847,7 +2856,7 @@ impl SslRef {
     /// Sets the ongoing session's supported groups by their named identifiers
     /// (formerly referred to as curves).
     #[corresponds(SSL_set1_groups)]
-    pub fn set_group_nids(&mut self, group_nids: &[i32]) -> Result<(), ErrorStack> {
+    pub fn set_group_nids(&mut self, group_nids: &[SslCurveNid]) -> Result<(), ErrorStack> {
         unsafe {
             cvt_0i(ffi::SSL_set1_groups(
                 self.as_ptr(),


### PR DESCRIPTION
**Description**
- Exposes BoringSSL method `SslRef::set_groups` -> `SSL_set1_groups` to directly set curve groups against an ongoing SSL session. This is necessary because in boringssl, calling `SSL_set_SSL_CTX` to switch the `SSL_CTX` does not update the supported group list (supported_group_list) on the existing SSL session object. We must set the curve list directly on the session after the SSL object is created but before the handshake begins.
![b377876c-b3eb-492f-b392-b18746ba605a](https://github.com/user-attachments/assets/da72c736-a2f4-4efd-85fc-a96e83cac69b)

- `SSL_set1_groups` is more efficient than the currently exposed `SslRef::set_curves_list` -> `SSL_set1_groups_list` which uses more complicated parsing logic to [parse colon delimited](https://github.com/google/boringssl/blob/bf4cf6938a77f1aca83ef529dce96681efd1e6c5/ssl/ssl_lib.cc#L1861) groups in string
![113e324c-a2a1-489f-b65c-6300f1366c8a](https://github.com/user-attachments/assets/bbd7e940-39e3-4509-a20e-f423317f0470)

- Exposes BoringSSL method `SslRef::set_options` -> `SSL_set_options` to directly set options against an ongoing SSL session (ex. enable `boring::ssl::SslOptions::CIPHER_SERVER_PREFERENCE` for a specific SNI only)