### PR TITLE
Add `X509_STORE_CTX_get0_cert` interface

### DIFF
--- a/boring/src/ssl/test/server.rs
+++ b/boring/src/ssl/test/server.rs
@@ -36,6 +36,24 @@ impl Server {
         }
     }
 
+    /// Serves the leaf and the root together.
+    pub fn builder_full_chain() -> Builder {
+        let mut ctx = SslContext::builder(SslMethod::tls()).unwrap();
+        // Uses certs.pem instead of cert.pem.
+        ctx.set_certificate_chain_file("test/certs.pem").unwrap();
+        ctx.set_private_key_file("test/key.pem", SslFiletype::PEM)
+            .unwrap();
+
+        Builder {
+            ctx,
+            ssl_cb: Box::new(|_| {}),
+            io_cb: Box::new(|_| {}),
+            err_cb: Box::new(|_| {}),
+            should_error: false,
+            expected_connections_count: 1,
+        }
+    }
+
     pub fn client(&self) -> ClientBuilder {
         ClientBuilder {
             ctx: SslContext::builder(SslMethod::tls()).unwrap(),

--- a/boring/src/x509/mod.rs
+++ b/boring/src/x509/mod.rs
@@ -209,6 +209,20 @@ impl X509StoreContextRef {
             }
         }
     }
+
+    /// Returns a reference to the certificate being verified.
+    /// May return None if a raw public key is being verified.
+    #[corresponds(X509_STORE_CTX_get0_cert)]
+    pub fn cert(&self) -> Option<&X509Ref> {
+        unsafe {
+            let ptr = ffi::X509_STORE_CTX_get0_cert(self.as_ptr());
+            if ptr.is_null() {
+                None
+            } else {
+                Some(X509Ref::from_ptr(ptr))
+            }
+        }
+    }
 }
 
 /// A builder used to construct an `X509`.


### PR DESCRIPTION
This method reliably retrieves the certificate the `X509_STORE_CTX` is verifying, unlike `X509_STORE_CTX_get_current_cert`, which may return the "problematic" cert when verification fails.