### PR TITLE
Revert "feat(x509): Implement `Clone` for `X509Store` (#339)"

### DIFF
--- a/boring/src/x509/store.rs
+++ b/boring/src/x509/store.rs
@@ -125,23 +125,6 @@ foreign_type_and_impl_send_sync! {
     pub struct X509Store;
 }
 
-impl Clone for X509Store {
-    fn clone(&self) -> Self {
-        (**self).to_owned()
-    }
-}
-
-impl ToOwned for X509StoreRef {
-    type Owned = X509Store;
-
-    fn to_owned(&self) -> Self::Owned {
-        unsafe {
-            ffi::X509_STORE_up_ref(self.as_ptr());
-            X509Store::from_ptr(self.as_ptr())
-        }
-    }
-}
-
 impl X509StoreRef {
     /// **Warning: this method is unsound**
     ///


### PR DESCRIPTION
This reverts commit 49a8d0906a5b96ac0e06f6110c3fc49889c2f995.

See <https://github.com/cloudflare/boring/pull/120>.