### PR TITLE
Improve X509StoreContext initialization API

### DIFF
--- a/boring/src/lib.rs
+++ b/boring/src/lib.rs
@@ -108,6 +108,8 @@ extern crate libc;
 #[cfg(test)]
 extern crate hex;
 
+use std::ffi::{c_long, c_void};
+
 #[doc(inline)]
 pub use crate::ffi::init;
 
@@ -191,5 +193,18 @@ fn cvt_n(r: c_int) -> Result<c_int, ErrorStack> {
         Err(ErrorStack::get())
     } else {
         Ok(r)
+    }
+}
+
+unsafe extern "C" fn free_data_box<T>(
+    _parent: *mut c_void,
+    ptr: *mut c_void,
+    _ad: *mut ffi::CRYPTO_EX_DATA,
+    _idx: c_int,
+    _argl: c_long,
+    _argp: *mut c_void,
+) {
+    if !ptr.is_null() {
+        drop(Box::<T>::from_raw(ptr as *mut T));
     }
 }

--- a/boring/src/ssl/mod.rs
+++ b/boring/src/ssl/mod.rs
@@ -58,7 +58,7 @@
 //! }
 //! ```
 use foreign_types::{ForeignType, ForeignTypeRef, Opaque};
-use libc::{c_char, c_int, c_long, c_uchar, c_uint, c_void};
+use libc::{c_char, c_int, c_uchar, c_uint, c_void};
 use openssl_macros::corresponds;
 use std::any::TypeId;
 use std::collections::HashMap;
@@ -81,7 +81,6 @@ use crate::dh::DhRef;
 use crate::ec::EcKeyRef;
 use crate::error::ErrorStack;
 use crate::ex_data::Index;
-use crate::ffi;
 use crate::nid::Nid;
 use crate::pkey::{HasPrivate, PKeyRef, Params, Private};
 use crate::srtp::{SrtpProtectionProfile, SrtpProtectionProfileRef};
@@ -95,6 +94,7 @@ use crate::x509::{
     X509Name, X509Ref, X509StoreContextRef, X509VerifyError, X509VerifyResult, X509,
 };
 use crate::{cvt, cvt_0i, cvt_n, cvt_p, init};
+use crate::{ffi, free_data_box};
 
 pub use self::async_callbacks::{
     AsyncPrivateKeyMethod, AsyncPrivateKeyMethodError, AsyncSelectCertError, BoxCustomVerifyFinish,
@@ -438,19 +438,6 @@ static SESSION_CTX_INDEX: LazyLock<Index<Ssl, SslContext>> =
 #[cfg(feature = "rpk")]
 static RPK_FLAG_INDEX: LazyLock<Index<SslContext, bool>> =
     LazyLock::new(|| SslContext::new_ex_index().unwrap());
-
-unsafe extern "C" fn free_data_box<T>(
-    _parent: *mut c_void,
-    ptr: *mut c_void,
-    _ad: *mut ffi::CRYPTO_EX_DATA,
-    _idx: c_int,
-    _argl: c_long,
-    _argp: *mut c_void,
-) {
-    if !ptr.is_null() {
-        drop(Box::<T>::from_raw(ptr as *mut T));
-    }
-}
 
 /// An error returned from the SNI callback.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]

--- a/boring/src/x509/mod.rs
+++ b/boring/src/x509/mod.rs
@@ -131,8 +131,6 @@ impl X509StoreContextRef {
     ///
     /// This can be used to provide data to callbacks registered with the context. Use the
     /// `Ssl::new_ex_index` method to create an `Index`.
-    ///
-    /// The previous value, if any, will be returned.
     #[corresponds(X509_STORE_CTX_set_ex_data)]
     pub fn set_ex_data<T>(&mut self, index: Index<X509StoreContext, T>, data: T) {
         if let Some(old) = self.ex_data_mut(index) {
@@ -207,7 +205,14 @@ impl X509StoreContextRef {
         }
     }
 
-    pub fn init_without_cleanup(
+    /// Initializes this context with the given certificate, certificates chain and certificate
+    /// store.
+    ///
+    /// * `trust` - The certificate store with the trusted certificates.
+    /// * `cert` - The certificate that should be verified.
+    /// * `cert_chain` - The certificates chain.
+    #[corresponds(X509_STORE_CTX_init)]
+    pub fn reset_with_context_data(
         &mut self,
         trust: store::X509Store,
         cert: X509,

--- a/boring/src/x509/tests/mod.rs
+++ b/boring/src/x509/tests/mod.rs
@@ -451,14 +451,26 @@ fn test_verify_cert() {
     let mut store_bldr = X509StoreBuilder::new().unwrap();
     store_bldr.add_cert(ca).unwrap();
     let store = store_bldr.build();
+    let empty_store = X509StoreBuilder::new().unwrap().build();
 
     let mut context = X509StoreContext::new().unwrap();
     assert!(context
         .init(&store, &cert, &chain, |c| c.verify_cert())
         .unwrap());
+    assert!(!context
+        .init(&empty_store, &cert, &chain, |c| c.verify_cert())
+        .unwrap());
     assert!(context
         .init(&store, &cert, &chain, |c| c.verify_cert())
         .unwrap());
+
+    context
+        .reset_with_context_data(empty_store, cert.clone(), Stack::new().unwrap())
+        .unwrap();
+    assert!(!context.verify_cert().unwrap());
+
+    context.reset_with_context_data(store, cert, chain).unwrap();
+    assert!(context.verify_cert().unwrap());
 }
 
 #[test]


### PR DESCRIPTION
We introduce `X509StoreContextRef::init_without_cleanup`.

Function `X509_STORE_CTX_init` requires its arguments to outlive the store context, which is why `X509StoreContextRef::init` takes a closure which is guaranteed to be followed by a call to `X509_STORE_CTX_cleanup`.

We can avoid that by using the store context's ex data to store and own the arguments that were passed to `X509_STORE_CTX_init`.