### PR TITLE
Ensure we call X509_STORE_CTX_cleanup on error path too

### DIFF
--- a/boring/src/x509/mod.rs
+++ b/boring/src/x509/mod.rs
@@ -130,14 +130,15 @@ impl X509StoreContextRef {
         }
 
         unsafe {
+            let cleanup = Cleanup(self);
+
             cvt(ffi::X509_STORE_CTX_init(
-                self.as_ptr(),
+                cleanup.0.as_ptr(),
                 trust.as_ptr(),
                 cert.as_ptr(),
                 cert_chain.as_ptr(),
             ))?;
 
-            let cleanup = Cleanup(self);
             with_context(cleanup.0)
         }
     }


### PR DESCRIPTION
As X509_STORE_CTX_init may fail after setting some values that should outlive the store context, we must ensure we clean things up on its error path too.

We also know it's always ok to call X509_STORE_CTX_cleanupas X509_STORE_CTX_init starts with a call to it.