### PR TITLE
Upgrade bindgen to v0.72.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ boring-sys = { version = "4.17.0", path = "./boring-sys" }
 boring = { version = "4.17.0", path = "./boring" }
 tokio-boring = { version = "4.17.0", path = "./tokio-boring" }
 
-bindgen = { version = "0.71.1", default-features = false, features = ["runtime"] }
+bindgen = { version = "0.72.0", default-features = false, features = ["runtime"] }
 bytes = "1"
 cmake = "0.1.18"
 fs_extra = "1.3.0"


### PR DESCRIPTION
This release includes a fix for a build issue with the latest XCode release, as seen in https://github.com/signalapp/libsignal/issues/615.