### PR TITLE
Support TARGET_CC and CC_{target}

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,8 +141,8 @@ jobs:
           apt_packages: gcc-arm-linux-gnueabi g++-arm-linux-gnueabi
           check_only: true
           custom_env:
-            CC: arm-linux-gnueabi-gcc
-            CXX: arm-linux-gnueabi-g++
+            CC_arm-unknown-linux-gnueabi: arm-linux-gnueabi-gcc
+            CXX_arm-unknown-linux-gnueabi: arm-linux-gnueabi-g++
             CARGO_TARGET_ARM_UNKNOWN_LINUX_GNUEABI_LINKER: arm-linux-gnueabi-g++
         - thing: aarch64-linux
           target: aarch64-unknown-linux-gnu
@@ -151,8 +151,8 @@ jobs:
           apt_packages: crossbuild-essential-arm64
           check_only: true
           custom_env:
-            CC: aarch64-linux-gnu-gcc
-            CXX: aarch64-linux-gnu-g++
+            CC_aarch64_unknown_linux_gnu: aarch64-linux-gnu-gcc
+            CXX_aarch64_unknown_linux_gnu: aarch64-linux-gnu-g++
             CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-g++
         - thing: arm64-macos
           target: aarch64-apple-darwin

--- a/boring-sys/build/config.rs
+++ b/boring-sys/build/config.rs
@@ -36,6 +36,9 @@ pub(crate) struct Env {
     pub(crate) android_ndk_home: Option<PathBuf>,
     pub(crate) cmake_toolchain_file: Option<PathBuf>,
     pub(crate) cpp_runtime_lib: Option<OsString>,
+    /// C compiler (ignored if using FIPS)
+    pub(crate) cc: Option<OsString>,
+    pub(crate) cxx: Option<OsString>,
     pub(crate) docs_rs: bool,
 }
 
@@ -146,18 +149,15 @@ impl Env {
         const NORMAL_PREFIX: &str = "BORING_BSSL";
         const FIPS_PREFIX: &str = "BORING_BSSL_FIPS";
 
+        let var_prefix = if host == target { "HOST" } else { "TARGET" };
         let target_with_underscores = target.replace('-', "_");
 
-        // Logic stolen from cmake-rs.
-        let target_var = |name: &str| {
-            let kind = if host == target { "HOST" } else { "TARGET" };
-
-            // TODO(rmehra): look for just `name` first, as most people just set that
+        let target_only_var = |name: &str| {
             var(&format!("{name}_{target}"))
                 .or_else(|| var(&format!("{name}_{target_with_underscores}")))
-                .or_else(|| var(&format!("{kind}_{name}")))
-                .or_else(|| var(name))
+                .or_else(|| var(&format!("{var_prefix}_{name}")))
         };
+        let target_var = |name: &str| target_only_var(name).or_else(|| var(name));
 
         let boringssl_var = |name: &str| {
             // The passed name is the non-fips version of the environment variable,
@@ -186,6 +186,9 @@ impl Env {
             android_ndk_home: target_var("ANDROID_NDK_HOME").map(Into::into),
             cmake_toolchain_file: target_var("CMAKE_TOOLCHAIN_FILE").map(Into::into),
             cpp_runtime_lib: target_var("BORING_BSSL_RUST_CPPLIB"),
+            // matches the `cc` crate
+            cc: target_only_var("CC"),
+            cxx: target_only_var("CXX"),
             docs_rs: var("DOCS_RS").is_some(),
         }
     }

--- a/boring-sys/build/main.rs
+++ b/boring-sys/build/main.rs
@@ -216,6 +216,15 @@ fn get_boringssl_cmake_config(config: &Config) -> cmake::Config {
             .define("CMAKE_ASM_COMPILER_TARGET", &config.target);
     }
 
+    if !config.features.fips {
+        if let Some(cc) = &config.env.cc {
+            boringssl_cmake.define("CMAKE_C_COMPILER", cc);
+        }
+        if let Some(cxx) = &config.env.cxx {
+            boringssl_cmake.define("CMAKE_CXX_COMPILER", cxx);
+        }
+    }
+
     if let Some(sysroot) = &config.env.sysroot {
         boringssl_cmake.define("CMAKE_SYSROOT", sysroot);
     }


### PR DESCRIPTION
This makes parallel multi-platform builds easier. 

The github workflow intentionally uses inconsistent syntax to test fallbacks in `target_var`.