### PR TITLE
Add binding for X509_check_ip_asc

### DIFF
--- a/boring/src/x509/mod.rs
+++ b/boring/src/x509/mod.rs
@@ -745,6 +745,13 @@ impl X509Ref {
         }
     }
 
+    #[corresponds(X509_check_ip_asc)]
+    pub fn check_ip_asc(&self, address: &str) -> Result<bool, ErrorStack> {
+        let c_str = CString::new(address).map_err(ErrorStack::internal_error)?;
+
+        unsafe { cvt_n(ffi::X509_check_ip_asc(self.as_ptr(), c_str.as_ptr(), 0)).map(|n| n == 1) }
+    }
+
     to_pem! {
         /// Serializes the certificate into a PEM-encoded X509 structure.
         ///

--- a/boring/src/x509/tests/mod.rs
+++ b/boring/src/x509/tests/mod.rs
@@ -513,3 +513,16 @@ fn test_load_subject_der() {
     ];
     X509Name::from_der(SUBJECT_DER).unwrap();
 }
+
+#[test]
+fn test_check_ip_asc() {
+    // Covers 127.0.0.1 and 0:0:0:0:0:0:0:1
+    let cert = include_bytes!("../../../test/alt_name_cert.pem");
+    let cert = X509::from_pem(cert).unwrap();
+
+    assert!(cert.check_ip_asc("127.0.0.1").unwrap());
+    assert!(!cert.check_ip_asc("127.0.0.2").unwrap());
+
+    assert!(cert.check_ip_asc("0:0:0:0:0:0:0:1").unwrap());
+    assert!(!cert.check_ip_asc("0:0:0:0:0:0:0:2").unwrap());
+}


### PR DESCRIPTION
Corresponds to https://boringssl.googlesource.com/boringssl.git/+/refs/heads/master/include/openssl/x509.h#4690