### PR TITLE
Remove `SslCurve` API

### DIFF
--- a/boring/src/ssl/mod.rs
+++ b/boring/src/ssl/mod.rs
@@ -2785,6 +2785,17 @@ impl SslRef {
         }
     }
 
+    /// Returns the curve ID (aka group ID) used for this `SslRef`.
+    #[corresponds(SSL_get_curve_id)]
+    #[must_use]
+    pub fn curve(&self) -> Option<u16> {
+        let curve_id = unsafe { ffi::SSL_get_curve_id(self.as_ptr()) };
+        if curve_id == 0 {
+            return None;
+        }
+        Some(curve_id)
+    }
+
     /// Returns an `ErrorCode` value for the most recent operation on this `SslRef`.
     #[corresponds(SSL_get_error)]
     #[must_use]

--- a/boring/src/ssl/test/mod.rs
+++ b/boring/src/ssl/test/mod.rs
@@ -952,6 +952,15 @@ fn sni_callback_swapped_ctx() {
 }
 
 #[test]
+fn get_curve() {
+    let server = Server::builder().build();
+    let client = server.client_with_root_ca();
+    let client_stream = client.connect();
+    let curve = client_stream.ssl().curve();
+    assert!(curve.is_some());
+}
+
+#[test]
 fn test_get_ciphers() {
     let ctx_builder = SslContext::builder(SslMethod::tls()).unwrap();
     let ctx_builder_ciphers: Vec<&str> = ctx_builder


### PR DESCRIPTION
This API is incompatible with the latest internal FIPS build. Namely, the various group identifiers have been renamed since the previous version.