### PR TITLE
Remove "pq-experimental" and "underscore-wildcards" features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Run clippy
         run: cargo clippy --all --all-targets
       - name: Check docs
-        run: cargo doc --no-deps -p boring -p boring-sys --features rpk,pq-experimental,underscore-wildcards
+        run: cargo doc --no-deps -p boring -p boring-sys --features rpk
         env:
           DOCS_RS: 1
   test:
@@ -357,15 +357,3 @@ jobs:
       shell: bash
     - run: cargo test --features rpk
       name: Run `rpk` tests
-    - run: cargo test --features pq-experimental
-      name: Run `pq-experimental` tests
-    - run: cargo test --features underscore-wildcards
-      name: Run `underscore-wildcards` tests
-    - run: cargo test --features pq-experimental,rpk
-      name: Run `pq-experimental,rpk` tests
-    - run: cargo test --features pq-experimental,underscore-wildcards
-      name: Run `pq-experimental,underscore-wildcards` tests
-    - run: cargo test --features rpk,underscore-wildcards
-      name: Run `rpk,underscore-wildcards` tests
-    - run: cargo test --features pq-experimental,rpk,underscore-wildcards
-      name: Run `pq-experimental,rpk,underscore-wildcards` tests

--- a/boring-sys/Cargo.toml
+++ b/boring-sys/Cargo.toml
@@ -41,7 +41,7 @@ include = [
 ]
 
 [package.metadata.docs.rs]
-features = ["rpk", "pq-experimental", "underscore-wildcards"]
+features = ["rpk"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
@@ -55,18 +55,6 @@ fips = []
 
 # Enables Raw public key API (https://datatracker.ietf.org/doc/html/rfc7250)
 rpk = []
-
-# Applies a patch (`patches/boring-pq.patch`) to the boringSSL source code that
-# enables support for PQ key exchange. This feature is necessary in order to
-# compile the bindings for the default branch of boringSSL (`deps/boringssl`).
-# Alternatively, a version of boringSSL that implements the same feature set
-# can be provided by setting `BORING_BSSL{,_FIPS}_SOURCE_PATH`.
-pq-experimental = []
-
-# Applies a patch (`patches/underscore-wildcards.patch`) to enable
-# `ffi::X509_CHECK_FLAG_UNDERSCORE_WILDCARDS`. Same caveats as
-# those for `pq-experimental` feature apply.
-underscore-wildcards = []
 
 [build-dependencies]
 bindgen = { workspace = true }

--- a/boring-sys/build/config.rs
+++ b/boring-sys/build/config.rs
@@ -16,9 +16,7 @@ pub(crate) struct Config {
 
 pub(crate) struct Features {
     pub(crate) fips: bool,
-    pub(crate) pq_experimental: bool,
     pub(crate) rpk: bool,
-    pub(crate) underscore_wildcards: bool,
 }
 
 pub(crate) struct Env {
@@ -89,11 +87,7 @@ impl Config {
             );
         }
 
-        let features_with_patches_enabled = self.features.rpk
-            || self.features.pq_experimental
-            || self.features.underscore_wildcards;
-
-        let patches_required = features_with_patches_enabled && !self.env.assume_patched;
+        let patches_required = self.features.rpk && !self.env.assume_patched;
 
         if is_precompiled_native_lib && patches_required {
             println!(
@@ -106,16 +100,9 @@ impl Config {
 impl Features {
     fn from_env() -> Self {
         let fips = env::var_os("CARGO_FEATURE_FIPS").is_some();
-        let pq_experimental = env::var_os("CARGO_FEATURE_PQ_EXPERIMENTAL").is_some();
         let rpk = env::var_os("CARGO_FEATURE_RPK").is_some();
-        let underscore_wildcards = env::var_os("CARGO_FEATURE_UNDERSCORE_WILDCARDS").is_some();
 
-        Self {
-            fips,
-            pq_experimental,
-            rpk,
-            underscore_wildcards,
-        }
+        Self { fips, rpk }
     }
 
     pub(crate) fn is_fips_like(&self) -> bool {

--- a/boring-sys/build/main.rs
+++ b/boring-sys/build/main.rs
@@ -433,15 +433,10 @@ fn ensure_patches_applied(config: &Config) -> io::Result<()> {
             native BoringSSL is expected to have the patches included"
         );
         return Ok(());
-    } else if config.env.source_path.is_some()
-        && (config.features.rpk
-            || config.features.pq_experimental
-            || config.features.underscore_wildcards)
-    {
+    } else if config.env.source_path.is_some() && config.features.rpk {
         panic!(
             "BORING_BSSL_ASSUME_PATCHED must be set when setting
-               BORING_BSSL_SOURCE_PATH and using any of the following
-               features: rpk, pq-experimental, underscore-wildcards"
+               BORING_BSSL_SOURCE_PATH and using the rpk feature"
         );
     }
 
@@ -456,20 +451,16 @@ fn ensure_patches_applied(config: &Config) -> io::Result<()> {
         run_command(Command::new("git").arg("init").current_dir(src_path))?;
     }
 
-    if config.features.pq_experimental {
-        println!("cargo:warning=applying experimental post quantum crypto patch to boringssl");
-        apply_patch(config, "boring-pq.patch")?;
-    }
+    println!("cargo:warning=applying experimental post quantum crypto patch to boringssl");
+    apply_patch(config, "boring-pq.patch")?;
 
     if config.features.rpk {
         println!("cargo:warning=applying RPK patch to boringssl");
         apply_patch(config, "rpk.patch")?;
     }
 
-    if config.features.underscore_wildcards {
-        println!("cargo:warning=applying underscore wildcards patch to boringssl");
-        apply_patch(config, "underscore-wildcards.patch")?;
-    }
+    println!("cargo:warning=applying underscore wildcards patch to boringssl");
+    apply_patch(config, "underscore-wildcards.patch")?;
 
     Ok(())
 }

--- a/boring/Cargo.toml
+++ b/boring/Cargo.toml
@@ -13,7 +13,7 @@ edition = { workspace = true }
 rust-version = "1.80"
 
 [package.metadata.docs.rs]
-features = ["rpk", "pq-experimental", "underscore-wildcards"]
+features = ["rpk"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
@@ -31,18 +31,6 @@ legacy-compat-deprecated = []
 # implements the same feature set can be provided by setting
 # `BORING_BSSL{,_FIPS}_SOURCE_PATH` and `BORING_BSSL{,_FIPS}_ASSUME_PATCHED`.
 rpk = ["boring-sys/rpk"]
-
-# Applies a patch to the boringSSL source code that enables support for PQ key
-# exchange. This feature is necessary in order to compile the bindings for the
-# default branch of boringSSL. Alternatively, a version of boringSSL that
-# implements the same feature set can be provided by setting
-# `BORING_BSSL{,_FIPS}_SOURCE_PATH` and `BORING_BSSL{,_FIPS}_ASSUME_PATCHED`.
-pq-experimental = ["boring-sys/pq-experimental"]
-
-# Applies a patch to enable
-# `ffi::X509_CHECK_FLAG_UNDERSCORE_WILDCARDS`. Same caveats as
-# those for `pq-experimental` feature apply.
-underscore-wildcards = ["boring-sys/underscore-wildcards"]
 
 [dependencies]
 bitflags = { workspace = true }

--- a/boring/src/ssl/test/mod.rs
+++ b/boring/src/ssl/test/mod.rs
@@ -610,7 +610,6 @@ fn verify_reject_underscore_hostname_with_wildcard() {
     client.connect_err();
 }
 
-#[cfg(feature = "underscore-wildcards")]
 #[test]
 fn verify_allow_underscore_hostname_with_wildcard() {
     let mut server = Server::builder();

--- a/boring/src/x509/verify.rs
+++ b/boring/src/x509/verify.rs
@@ -18,7 +18,6 @@ bitflags! {
         const MULTI_LABEL_WILDCARDS = ffi::X509_CHECK_FLAG_MULTI_LABEL_WILDCARDS as _;
         const SINGLE_LABEL_SUBDOMAINS = ffi::X509_CHECK_FLAG_SINGLE_LABEL_SUBDOMAINS as _;
         const NEVER_CHECK_SUBJECT = ffi::X509_CHECK_FLAG_NEVER_CHECK_SUBJECT as _;
-        #[cfg(feature = "underscore-wildcards")]
         const UNDERSCORE_WILDCARDS = ffi::X509_CHECK_FLAG_UNDERSCORE_WILDCARDS as _;
 
         #[deprecated(since = "0.10.6", note = "renamed to NO_WILDCARDS")]

--- a/hyper-boring/Cargo.toml
+++ b/hyper-boring/Cargo.toml
@@ -12,15 +12,12 @@ exclude = ["test/*"]
 rust-version = "1.80"
 
 [package.metadata.docs.rs]
-features = ["pq-experimental"]
+features = []
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 # Use a FIPS-validated version of boringssl.
 fips = ["boring/fips", "tokio-boring/fips"]
-
-# Enables experimental post-quantum crypto (https://blog.cloudflare.com/post-quantum-for-all/)
-pq-experimental = ["tokio-boring/pq-experimental"]
 
 [dependencies]
 antidote = { workspace = true }

--- a/tokio-boring/Cargo.toml
+++ b/tokio-boring/Cargo.toml
@@ -12,15 +12,12 @@ An implementation of SSL streams for Tokio backed by BoringSSL
 """
 
 [package.metadata.docs.rs]
-features = ["rpk", "pq-experimental"]
+features = ["rpk"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 # Use a FIPS-validated version of boringssl.
 fips = ["boring/fips", "boring-sys/fips"]
-
-# Enables experimental post-quantum crypto (https://blog.cloudflare.com/post-quantum-for-all/)
-pq-experimental = ["boring/pq-experimental"]
 
 # Enables Raw public key API (https://datatracker.ietf.org/doc/html/rfc7250)
 rpk = ["boring/rpk"]


### PR DESCRIPTION
When set, these features cause boring-sys to apply patches to the source before building BoringSSL. Instead, apply these patches unconditionally. This matches the semantcis of pre-compiled BoringSSL, where the library is expected to provide the features implemented by these patches.

We might want to do the same for "rpk", but currenlty our internal build of boringSSL doesn't appear to supply the following APIs:

```
ffi::SSL_CTX_set_nullchain_and_key
ffi::SSL_CTX_set_server_raw_public_key_certificate
```