### PR TITLE
Remove the "kx-*" features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,8 +363,6 @@ jobs:
       name: Run `underscore-wildcards` tests
     - run: cargo test --features pq-experimental,rpk
       name: Run `pq-experimental,rpk` tests
-    - run: cargo test --features kx-safe-default,pq-experimental
-      name: Run `kx-safe-default` tests
     - run: cargo test --features pq-experimental,underscore-wildcards
       name: Run `pq-experimental,underscore-wildcards` tests
     - run: cargo test --features rpk,underscore-wildcards

--- a/boring/Cargo.toml
+++ b/boring/Cargo.toml
@@ -44,28 +44,6 @@ pq-experimental = ["boring-sys/pq-experimental"]
 # those for `pq-experimental` feature apply.
 underscore-wildcards = ["boring-sys/underscore-wildcards"]
 
-# Controlling key exchange preferences at compile time
-
-# Choose key exchange preferences at compile time. This prevents the user from
-# choosing their own preferences.
-kx-safe-default = []
-
-# Support PQ key exchange. The client will prefer classical key exchange, but
-# will upgrade to PQ key exchange if requested by the server. This is the
-# safest option if you don't know if the peer supports PQ key exchange. This
-# feature implies "kx-safe-default".
-kx-client-pq-supported = ["kx-safe-default"]
-
-# Prefer PQ key exchange. The client will prefer PQ exchange, but fallback to
-# classical key exchange if requested by the server. This is the best option if
-# you know the peer supports PQ key exchange. This feature implies
-# "kx-safe-default" and "kx-client-pq-supported".
-kx-client-pq-preferred = ["kx-safe-default", "kx-client-pq-supported"]
-
-# Disable key exchange involving non-NIST key exchange on the client side.
-# Implies "kx-safe-default".
-kx-client-nist-required = ["kx-safe-default"]
-
 [dependencies]
 bitflags = { workspace = true }
 foreign-types = { workspace = true }

--- a/boring/src/ssl/test/mod.rs
+++ b/boring/src/ssl/test/mod.rs
@@ -952,30 +952,6 @@ fn sni_callback_swapped_ctx() {
     assert!(CALLED_BACK.load(Ordering::SeqCst));
 }
 
-#[cfg(feature = "kx-safe-default")]
-#[test]
-fn client_set_default_curves_list() {
-    let ssl_ctx = crate::ssl::SslContextBuilder::new(SslMethod::tls())
-        .unwrap()
-        .build();
-    let mut ssl = Ssl::new(&ssl_ctx).unwrap();
-
-    // Panics if Kyber768 missing in boringSSL.
-    ssl.client_set_default_curves_list();
-}
-
-#[cfg(feature = "kx-safe-default")]
-#[test]
-fn server_set_default_curves_list() {
-    let ssl_ctx = crate::ssl::SslContextBuilder::new(SslMethod::tls())
-        .unwrap()
-        .build();
-    let mut ssl = Ssl::new(&ssl_ctx).unwrap();
-
-    // Panics if Kyber768 missing in boringSSL.
-    ssl.server_set_default_curves_list();
-}
-
 #[test]
 fn get_curve() {
     let server = Server::builder().build();
@@ -994,7 +970,6 @@ fn get_curve_name() {
     assert_eq!(SslCurve::X25519.name(), Some("X25519"));
 }
 
-#[cfg(not(feature = "kx-safe-default"))]
 #[test]
 fn set_curves() {
     let mut ctx = SslContext::builder(SslMethod::tls()).unwrap();


### PR DESCRIPTION
The "kx-*" features control default key exchange preferences. Its implementation requires disabling APIs for manually setting curve preferences via `set_curves()` or `set_curves_list()`.

In practice, most teams need to be able to override default preferences at runtime anyway, which means these features were never really used. This commit gets rid of them, thereby reducing some complexity in the API.