### PR TITLE
Remove "pq-experimental", apply PQ patch by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Run clippy
         run: cargo clippy --all --all-targets
       - name: Check docs
-        run: cargo doc --no-deps -p boring -p boring-sys --features rpk,pq-experimental,underscore-wildcards
+        run: cargo doc --no-deps -p boring -p boring-sys --features rpk,underscore-wildcards
         env:
           DOCS_RS: 1
   test:
@@ -357,15 +357,7 @@ jobs:
       shell: bash
     - run: cargo test --features rpk
       name: Run `rpk` tests
-    - run: cargo test --features pq-experimental
-      name: Run `pq-experimental` tests
     - run: cargo test --features underscore-wildcards
       name: Run `underscore-wildcards` tests
-    - run: cargo test --features pq-experimental,rpk
-      name: Run `pq-experimental,rpk` tests
-    - run: cargo test --features pq-experimental,underscore-wildcards
-      name: Run `pq-experimental,underscore-wildcards` tests
     - run: cargo test --features rpk,underscore-wildcards
       name: Run `rpk,underscore-wildcards` tests
-    - run: cargo test --features pq-experimental,rpk,underscore-wildcards
-      name: Run `pq-experimental,rpk,underscore-wildcards` tests

--- a/boring-sys/Cargo.toml
+++ b/boring-sys/Cargo.toml
@@ -41,7 +41,7 @@ include = [
 ]
 
 [package.metadata.docs.rs]
-features = ["rpk", "pq-experimental", "underscore-wildcards"]
+features = ["rpk", "underscore-wildcards"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
@@ -56,16 +56,12 @@ fips = []
 # Enables Raw public key API (https://datatracker.ietf.org/doc/html/rfc7250)
 rpk = []
 
-# Applies a patch (`patches/boring-pq.patch`) to the boringSSL source code that
-# enables support for PQ key exchange. This feature is necessary in order to
-# compile the bindings for the default branch of boringSSL (`deps/boringssl`).
-# Alternatively, a version of boringSSL that implements the same feature set
-# can be provided by setting `BORING_BSSL{,_FIPS}_SOURCE_PATH`.
-pq-experimental = []
-
 # Applies a patch (`patches/underscore-wildcards.patch`) to enable
-# `ffi::X509_CHECK_FLAG_UNDERSCORE_WILDCARDS`. Same caveats as
-# those for `pq-experimental` feature apply.
+# `ffi::X509_CHECK_FLAG_UNDERSCORE_WILDCARDS`. This feature is necessary in
+# order to compile the bindings for the default branch of boringSSL
+# (`deps/boringssl`). Alternatively, a version of boringSSL that implements the
+# same feature set can be provided by setting
+# `BORING_BSSL{,_FIPS}_SOURCE_PATH`.
 underscore-wildcards = []
 
 [build-dependencies]

--- a/boring-sys/build/config.rs
+++ b/boring-sys/build/config.rs
@@ -16,7 +16,6 @@ pub(crate) struct Config {
 
 pub(crate) struct Features {
     pub(crate) fips: bool,
-    pub(crate) pq_experimental: bool,
     pub(crate) rpk: bool,
     pub(crate) underscore_wildcards: bool,
 }
@@ -89,9 +88,7 @@ impl Config {
             );
         }
 
-        let features_with_patches_enabled = self.features.rpk
-            || self.features.pq_experimental
-            || self.features.underscore_wildcards;
+        let features_with_patches_enabled = self.features.rpk || self.features.underscore_wildcards;
 
         let patches_required = features_with_patches_enabled && !self.env.assume_patched;
 
@@ -106,13 +103,11 @@ impl Config {
 impl Features {
     fn from_env() -> Self {
         let fips = env::var_os("CARGO_FEATURE_FIPS").is_some();
-        let pq_experimental = env::var_os("CARGO_FEATURE_PQ_EXPERIMENTAL").is_some();
         let rpk = env::var_os("CARGO_FEATURE_RPK").is_some();
         let underscore_wildcards = env::var_os("CARGO_FEATURE_UNDERSCORE_WILDCARDS").is_some();
 
         Self {
             fips,
-            pq_experimental,
             rpk,
             underscore_wildcards,
         }

--- a/boring-sys/build/main.rs
+++ b/boring-sys/build/main.rs
@@ -434,14 +434,12 @@ fn ensure_patches_applied(config: &Config) -> io::Result<()> {
         );
         return Ok(());
     } else if config.env.source_path.is_some()
-        && (config.features.rpk
-            || config.features.pq_experimental
-            || config.features.underscore_wildcards)
+        && (config.features.rpk || config.features.underscore_wildcards)
     {
         panic!(
             "BORING_BSSL_ASSUME_PATCHED must be set when setting
                BORING_BSSL_SOURCE_PATH and using any of the following
-               features: rpk, pq-experimental, underscore-wildcards"
+               features: rpk, underscore-wildcards"
         );
     }
 
@@ -456,10 +454,8 @@ fn ensure_patches_applied(config: &Config) -> io::Result<()> {
         run_command(Command::new("git").arg("init").current_dir(src_path))?;
     }
 
-    if config.features.pq_experimental {
-        println!("cargo:warning=applying experimental post quantum crypto patch to boringssl");
-        apply_patch(config, "boring-pq.patch")?;
-    }
+    println!("cargo:warning=applying post quantum crypto patch to boringssl");
+    apply_patch(config, "boring-pq.patch")?;
 
     if config.features.rpk {
         println!("cargo:warning=applying RPK patch to boringssl");

--- a/boring/Cargo.toml
+++ b/boring/Cargo.toml
@@ -13,7 +13,7 @@ edition = { workspace = true }
 rust-version = "1.80"
 
 [package.metadata.docs.rs]
-features = ["rpk", "pq-experimental", "underscore-wildcards"]
+features = ["rpk", "underscore-wildcards"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
@@ -32,16 +32,11 @@ legacy-compat-deprecated = []
 # `BORING_BSSL{,_FIPS}_SOURCE_PATH` and `BORING_BSSL{,_FIPS}_ASSUME_PATCHED`.
 rpk = ["boring-sys/rpk"]
 
-# Applies a patch to the boringSSL source code that enables support for PQ key
-# exchange. This feature is necessary in order to compile the bindings for the
-# default branch of boringSSL. Alternatively, a version of boringSSL that
-# implements the same feature set can be provided by setting
-# `BORING_BSSL{,_FIPS}_SOURCE_PATH` and `BORING_BSSL{,_FIPS}_ASSUME_PATCHED`.
-pq-experimental = ["boring-sys/pq-experimental"]
-
-# Applies a patch to enable
-# `ffi::X509_CHECK_FLAG_UNDERSCORE_WILDCARDS`. Same caveats as
-# those for `pq-experimental` feature apply.
+# Applies a patch to enable `ffi::X509_CHECK_FLAG_UNDERSCORE_WILDCARDS`. This
+# feature is necessary in order to compile the bindings for the default branch
+# of boringSSL. Alternatively, a version of boringSSL that implements the same
+# feature set can be provided by setting `BORING_BSSL{,_FIPS}_SOURCE_PATH` and
+# `BORING_BSSL{,_FIPS}_ASSUME_PATCHED`.
 underscore-wildcards = ["boring-sys/underscore-wildcards"]
 
 [dependencies]

--- a/hyper-boring/Cargo.toml
+++ b/hyper-boring/Cargo.toml
@@ -12,15 +12,12 @@ exclude = ["test/*"]
 rust-version = "1.80"
 
 [package.metadata.docs.rs]
-features = ["pq-experimental"]
+features = []
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 # Use a FIPS-validated version of boringssl.
 fips = ["boring/fips", "tokio-boring/fips"]
-
-# Enables experimental post-quantum crypto (https://blog.cloudflare.com/post-quantum-for-all/)
-pq-experimental = ["tokio-boring/pq-experimental"]
 
 [dependencies]
 antidote = { workspace = true }

--- a/tokio-boring/Cargo.toml
+++ b/tokio-boring/Cargo.toml
@@ -12,15 +12,12 @@ An implementation of SSL streams for Tokio backed by BoringSSL
 """
 
 [package.metadata.docs.rs]
-features = ["rpk", "pq-experimental"]
+features = ["rpk"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 # Use a FIPS-validated version of boringssl.
 fips = ["boring/fips", "boring-sys/fips"]
-
-# Enables experimental post-quantum crypto (https://blog.cloudflare.com/post-quantum-for-all/)
-pq-experimental = ["boring/pq-experimental"]
 
 # Enables Raw public key API (https://datatracker.ietf.org/doc/html/rfc7250)
 rpk = ["boring/rpk"]


### PR DESCRIPTION
Users can override the new default behavior in the usual way. The expectation is that the build of BoringSSL they provide the feature set implemented by the patch.