### PR TITLE
Add symbol prefixing feature for BoringSSL

### DIFF
--- a/.github/workflows/prefix.yml
+++ b/.github/workflows/prefix.yml
@@ -1,0 +1,103 @@
+name: prefix
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+jobs:
+  prefix-symbols:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            bin: ""
+            test: true
+            custom_env: {}
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            bin: ""
+            test: false
+            apt_packages: crossbuild-essential-arm64 binutils-multiarch
+            custom_env:
+              CC_aarch64_unknown_linux_gnu: aarch64-linux-gnu-gcc
+              CXX_aarch64_unknown_linux_gnu: aarch64-linux-gnu-g++
+              CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-g++
+          - target: armv7-linux-androideabi
+            os: ubuntu-latest
+            bin: ndk
+            test: false
+            custom_env: {}
+          - target: aarch64-linux-android
+            os: ubuntu-latest
+            bin: ndk
+            test: false
+            custom_env: {}
+          - target: x86_64-linux-android
+            os: ubuntu-latest
+            bin: ndk
+            test: false
+            custom_env: {}
+          - target: i686-linux-android
+            os: ubuntu-latest
+            bin: ndk
+            test: false
+            custom_env: {}
+    defaults:
+      run:
+        working-directory: test-project
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+      - name: Create test project
+        working-directory: .
+        run: |
+          cargo init test-project
+          cd test-project
+          cargo add boring-sys --path ../boring-sys/
+          cargo add openssl-sys -F vendored
+          echo "fn main() {boring_sys::init(); openssl_sys::init();}" > src/main.rs
+      - name: Install Rust toolchain
+        shell: bash
+        run: rustup target add ${{ matrix.target }}
+      - name: Install target-specific APT dependencies
+        if: matrix.apt_packages != ''
+        run: sudo apt update && sudo apt install -y ${{ matrix.apt_packages }}
+      - name: Install cargo-ndk
+        if: contains(matrix.target, 'android')
+        run: |
+          cargo install cargo-ndk
+          # Openssl fix for i686: https://github.com/rust-openssl/rust-openssl/issues/2163#issuecomment-2692363343
+          echo "ANDROID_NDK=$ANDROID_NDK_LATEST_HOME" >> $GITHUB_ENV
+          echo "ANDROID_NDK_HOME=$ANDROID_NDK_LATEST_HOME" >> $GITHUB_ENV
+          echo "ANDROID_NDK_ROOT=$ANDROID_NDK_LATEST_HOME" >> $GITHUB_ENV
+          echo "CARGO_TARGET_I686_LINUX_ANDROID_RUSTFLAGS=-C link-arg=-lclang_rt.builtins-i686-android -C link-arg=-L${ANDROID_NDK_LATEST_HOME}/toolchains/llvm/prebuilt/linux-x86_64/lib/clang/21/lib/linux/" >> $GITHUB_ENV
+      - name: Build without prefixing
+        env: ${{ matrix.custom_env }}
+        shell: bash
+        run: |
+          RC=0
+          cargo ${{ matrix.bin }} build --target ${{ matrix.target }} >logs 2>&1 || RC=$?
+          if [[ $RC == 0 || (! $(cat logs | grep "lld: error: duplicate symbol") && ! $(cat logs | grep "multiple definition of")) ]]; then
+            cat logs
+            echo "Build finished without duplicate symbols: $RC"
+            exit 1
+          fi
+          cat logs
+          echo "Failed as expected: $RC"
+      - name: Add prefix-symbols feature
+        shell: bash
+        run: cargo add boring-sys --path ../boring-sys/ -F prefix-symbols
+      - name: Build with prefixing
+        env: ${{ matrix.custom_env }}
+        shell: bash
+        run: cargo ${{ matrix.bin }} build --target ${{ matrix.target }}
+      - name: Check if the is no runtime failures
+        if: matrix.test == true
+        shell: bash
+        run: cargo ${{ matrix.bin }} run --target ${{ matrix.target }}

--- a/boring-sys/Cargo.toml
+++ b/boring-sys/Cargo.toml
@@ -64,6 +64,10 @@ rpk = []
 # `BORING_BSSL{,_FIPS}_SOURCE_PATH`.
 underscore-wildcards = []
 
+# Add a prefix to all symbols in libcrypto and libssl to prevent conflicts
+# with other OpenSSL or BoringSSL versions that might be linked in the same process.
+prefix-symbols = []
+
 [build-dependencies]
 bindgen = { workspace = true }
 cmake = { workspace = true }

--- a/boring-sys/build/config.rs
+++ b/boring-sys/build/config.rs
@@ -18,6 +18,7 @@ pub(crate) struct Features {
     pub(crate) fips: bool,
     pub(crate) rpk: bool,
     pub(crate) underscore_wildcards: bool,
+    pub(crate) prefix_symbols: bool,
 }
 
 pub(crate) struct Env {
@@ -105,11 +106,13 @@ impl Features {
         let fips = env::var_os("CARGO_FEATURE_FIPS").is_some();
         let rpk = env::var_os("CARGO_FEATURE_RPK").is_some();
         let underscore_wildcards = env::var_os("CARGO_FEATURE_UNDERSCORE_WILDCARDS").is_some();
+        let prefix_symbols = env::var_os("CARGO_FEATURE_PREFIX_SYMBOLS").is_some();
 
         Self {
             fips,
             rpk,
             underscore_wildcards,
+            prefix_symbols,
         }
     }
 

--- a/boring-sys/build/prefix.rs
+++ b/boring-sys/build/prefix.rs
@@ -1,0 +1,89 @@
+use crate::{config::Config, pick_best_android_ndk_toolchain, run_command};
+use std::{fs, io::Write, path::PathBuf, process::Command};
+
+// The prefix to add to all symbols
+// Using crate name to avoid collisions with other projects
+const PREFIX: &str = env!("CARGO_CRATE_NAME");
+
+// Callback to add a `link_name` macro with the prefix to all generated bindings
+#[derive(Debug)]
+pub struct PrefixCallback;
+
+impl bindgen::callbacks::ParseCallbacks for PrefixCallback {
+    fn generated_link_name_override(
+        &self,
+        item_info: bindgen::callbacks::ItemInfo<'_>,
+    ) -> Option<String> {
+        Some(format!("{PREFIX}_{}", item_info.name))
+    }
+}
+
+fn android_toolchain(config: &Config) -> PathBuf {
+    let mut android_bin_path = config
+        .env
+        .android_ndk_home
+        .clone()
+        .expect("Please set ANDROID_NDK_HOME for Android build");
+    android_bin_path.extend(["toolchains", "llvm", "prebuilt"]);
+    android_bin_path.push(pick_best_android_ndk_toolchain(&android_bin_path).unwrap());
+    android_bin_path.push("bin");
+    android_bin_path
+}
+
+pub fn prefix_symbols(config: &Config) {
+    // List static libraries to prefix symbols in
+    let static_libs: Vec<PathBuf> = [
+        config.out_dir.join("build"),
+        config.out_dir.join("build").join("ssl"),
+        config.out_dir.join("build").join("crypto"),
+    ]
+    .iter()
+    .flat_map(|dir| {
+        ["libssl.a", "libcrypto.a"]
+            .into_iter()
+            .map(move |file| PathBuf::from(dir).join(file))
+    })
+    .filter(|p| p.exists())
+    .collect();
+
+    // Use `nm` to list symbols in these static libraries
+    let nm = match &*config.target_os {
+        "android" => android_toolchain(config).join("llvm-nm"),
+        _ => PathBuf::from("nm"),
+    };
+    let out = run_command(Command::new(nm).args(&static_libs)).unwrap();
+    let mut redefine_syms: Vec<String> = String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .filter(|l| {
+            [" T ", " D ", " B ", " C ", " R ", " W "]
+                .iter()
+                .any(|s| l.contains(s))
+        })
+        .filter_map(|l| l.split_whitespace().nth(2).map(|s| s.to_string()))
+        .filter(|l| !l.starts_with("_"))
+        .map(|l| format!("{l} {PREFIX}_{l}"))
+        .collect();
+    redefine_syms.sort();
+    redefine_syms.dedup();
+
+    let redefine_syms_path = config.out_dir.join("redefine_syms.txt");
+    let mut f = fs::File::create(&redefine_syms_path).unwrap();
+    for sym in &redefine_syms {
+        writeln!(f, "{sym}").unwrap();
+    }
+    f.flush().unwrap();
+
+    // Use `objcopy` to prefix symbols in these static libraries
+    let objcopy = match &*config.target_os {
+        "android" => android_toolchain(config).join("llvm-objcopy"),
+        _ => PathBuf::from("objcopy"),
+    };
+    for static_lib in &static_libs {
+        run_command(
+            Command::new(&objcopy)
+                .arg(format!("--redefine-syms={}", redefine_syms_path.display()))
+                .arg(static_lib),
+        )
+        .unwrap();
+    }
+}

--- a/boring/Cargo.toml
+++ b/boring/Cargo.toml
@@ -39,6 +39,10 @@ rpk = ["boring-sys/rpk"]
 # `BORING_BSSL{,_FIPS}_ASSUME_PATCHED`.
 underscore-wildcards = ["boring-sys/underscore-wildcards"]
 
+# Add a prefix to all symbols in libcrypto and libssl to prevent conflicts
+# with other OpenSSL or BoringSSL versions that might be linked in the same process.
+prefix-symbols = ["boring-sys/prefix-symbols"]
+
 [dependencies]
 bitflags = { workspace = true }
 foreign-types = { workspace = true }


### PR DESCRIPTION
## Goal

Add a prefix to all symbols in libcrypto and libssl to prevent conflicts with other OpenSSL or BoringSSL versions that might be linked in the same process.

## Why?

When statically linking both OpenSSL and BoringSSL in the same project, we encountered **duplicate symbols**, for example:

```rust
rust-lld: error: duplicate symbol: AES_encrypt
>>> defined at aes-x86_64.s:328 (crypto/aes/aes-x86_64.s:328)
>>>            libcrypto-lib-aes-x86_64.o:(AES_encrypt) in archive /home/user/debug/target/debug/deps/libopenssl_sys-aa966f6339bd703d.rlib
>>> defined at aes.c:62 (/home/user/debug/target/debug/build/boring-sys-daeba9923fc21b33/out/boringssl/src/crypto/fipsmodule/aes/aes.c:62)
 >>>            bcm.c.o:(.text.AES_encrypt+0x0) in archive /home/user/debug/target/debug/deps/libboring_sys-b3f993188e8b17ea.rlib
```

## How?

The first approach was to use the BoringSSL-provided Go script `make_prefix_headers.go`. It mostly worked, but:

- It required two compilation steps: first to **build the static libraries** and extract symbols with `read_symbols.go`, then to generate `boringssl_prefix_symbols.h` with `make_prefix_headers.go`, and finally **rebuild again the static libraries** with this header. (We could have prebuilt it [like gRPC does](https://github.com/grpc/grpc/blob/master/tools/distrib/generate_boringssl_prefix_header.sh), but I preferred a fully automated workflow.)
- Some ASM/Perl-generated symbols were missed (even if present in `boringssl_prefix_symbols.h`), which I ended up fixing with the Binutils `objcopy` tool, not very straightforward.
- It required Go to run.

Therefore, I decided to use only the Binutils tools `nm` and `objcopy` to fully automate the symbol prefixing.

Steps (build.rs):

1. List static libraries to prefix symbols in (`libssl.a` and `libcrypto.a`).
2. Use `nm` to list all exported symbols in these static libraries.
3. Generate a mapping file and use `objcopy` to prefix all symbols.
4. Update the generated bindings (`bindings.rs`) with `#[link_name]` where necessary.

## Cross-compilation

Currently, this workflow is tested for Linux and Android only.

For Android, the target-specific `nm` and `objcopy` from the NDK are used.

macOS/iOS and Windows toolchains are **not tested**. I currently don’t have access to a macOS environment and have limited experience with Windows toolchains.

## Usage

I've added an opt-in feature `prefix-symbols`, as it is not tested on macOS/iOS/Windows yet.

```bash
cargo add boring --features prefix-symbols
```
