### PR TITLE
Fix peer_cert_chain doc

### DIFF
--- a/boring/src/ssl/mod.rs
+++ b/boring/src/ssl/mod.rs
@@ -3160,7 +3160,7 @@ impl SslRef {
     ///
     /// On the client side, the chain includes the leaf certificate, but on the server side it does
     /// not. Fun!
-    #[corresponds(SSL_get_peer_certificate)]
+    #[corresponds(SSL_get_peer_cert_chain)]
     #[must_use]
     pub fn peer_cert_chain(&self) -> Option<&StackRef<X509>> {
         #[cfg(feature = "rpk")]


### PR DESCRIPTION
The `peer_cert_chain` method maps to `SSL_get_peer_cert_chain` (a certificate chain), whereas the documentation currently references `SSL_get_peer_certificate` (the leaf only). This appears to be a copy/paste error during the introduction of the `corresponds` macro here.  References: [public docs](https://docs.openssl.org/master/man3/SSL_get_peer_cert_chain/#description).