### PR TITLE
Bump version to v5, allow v5 use v4-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.0.0-alpha.3"
+version = "5.0.0"
 repository = "https://github.com/cloudflare/boring"
 edition = "2021"
 
@@ -19,9 +19,9 @@ tag-prefix = ""
 publish = false
 
 [workspace.dependencies]
-boring-sys = { version = "5.0.0-alpha.3", path = "./boring-sys" }
-boring = { version = "5.0.0-alpha.3", path = "./boring" }
-tokio-boring = { version = "5.0.0-alpha.3", path = "./tokio-boring" }
+boring-sys = { version = ">=4.21.1, <6.0.0", path = "./boring-sys" } # Cargo doesn't like prerelease ranges. ok as of "5.0.0"
+boring = { version = "5.0.0", path = "./boring" }
+tokio-boring = { version = "5.0.0", path = "./tokio-boring" }
 
 bindgen = { version = "0.72.0", default-features = false, features = ["runtime"] }
 bitflags = "2.9"

--- a/boring/Cargo.toml
+++ b/boring/Cargo.toml
@@ -17,6 +17,9 @@ features = ["rpk", "underscore-wildcards"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
+# Enable SslCredential (requires boring-sys v5)
+credential = []
+
 # Controlling the build
 
 # Use a FIPS-validated version of BoringSSL.
@@ -34,7 +37,7 @@ pq-experimental = []
 # default branch of boringSSL. Alternatively, a version of boringSSL that
 # implements the same feature set can be provided by setting
 # `BORING_BSSL{,_FIPS}_SOURCE_PATH` and `BORING_BSSL{,_FIPS}_ASSUME_PATCHED`.
-rpk = ["boring-sys/rpk"]
+rpk = ["credential", "boring-sys/rpk"]
 
 # Applies a patch to enable `ffi::X509_CHECK_FLAG_UNDERSCORE_WILDCARDS`. This
 # feature is necessary in order to compile the bindings for the default branch

--- a/boring/src/ssl/async_callbacks.rs
+++ b/boring/src/ssl/async_callbacks.rs
@@ -4,8 +4,10 @@ use super::{
     Ssl, SslAlert, SslContextBuilder, SslRef, SslSession, SslSignatureAlgorithm, SslVerifyError,
     SslVerifyMode,
 };
+#[cfg(feature = "credential")]
 use crate::error::ErrorStack;
 use crate::ex_data::Index;
+#[cfg(feature = "credential")]
 use crate::ssl::SslCredentialBuilder;
 use std::convert::identity;
 use std::future::Future;
@@ -173,6 +175,7 @@ impl SslContextBuilder {
     }
 }
 
+#[cfg(feature = "credential")]
 impl SslCredentialBuilder {
     /// Configures a custom private key method on the context.
     ///

--- a/boring/src/ssl/mod.rs
+++ b/boring/src/ssl/mod.rs
@@ -108,6 +108,7 @@ pub use self::async_callbacks::{
 pub use self::connector::{
     ConnectConfiguration, SslAcceptor, SslAcceptorBuilder, SslConnector, SslConnectorBuilder,
 };
+#[cfg(feature = "credential")]
 pub use self::credential::{SslCredential, SslCredentialBuilder, SslCredentialRef};
 pub use self::ech::{SslEchKeys, SslEchKeysRef};
 pub use self::error::{Error, ErrorCode, HandshakeError};
@@ -116,6 +117,7 @@ mod async_callbacks;
 mod bio;
 mod callbacks;
 mod connector;
+#[cfg(feature = "credential")]
 mod credential;
 mod ech;
 mod error;
@@ -2025,6 +2027,7 @@ impl SslContextBuilder {
 
     /// Adds a credential.
     #[corresponds(SSL_CTX_add1_credential)]
+    #[cfg(feature = "credential")]
     pub fn add_credential(&mut self, credential: &SslCredentialRef) -> Result<(), ErrorStack> {
         unsafe {
             cvt_0i(ffi::SSL_CTX_add1_credential(
@@ -3844,6 +3847,7 @@ impl SslRef {
 
     /// Adds a credential.
     #[corresponds(SSL_add1_credential)]
+    #[cfg(feature = "credential")]
     pub fn add_credential(&mut self, credential: &SslCredentialRef) -> Result<(), ErrorStack> {
         unsafe { cvt_0i(ffi::SSL_add1_credential(self.as_ptr(), credential.as_ptr())).map(|_| ()) }
     }


### PR DESCRIPTION
When https://github.com/cloudflare/boring/pull/406 is released, this will be backwards-compatible with projects using `boring-sys` v4.

This will be crucial for users of `boring`, because `boring` v4 and v5 can co-exist in the dependency tree (it's merely a bloat), but `boring-sys` v4 and v5 can't (due to linking C having globals all over the place). boring v5 with boring-sys v4 will let projects upgrade their dependencies gradually.