### PR TITLE
Can't build with clang-12 to libc++ mismatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,45 +306,6 @@ jobs:
     - name: Build for ${{ matrix.target }}
       run: cargo build --target ${{ matrix.target }} --all-targets
 
-  cross-build-fips:
-    name: Cross build from macOS to Linux (FIPS)
-    runs-on: macos-13 # Need an Intel (x86_64) runner for Clang 12.0.0
-    strategy:
-      matrix:
-        include:
-          - target: x86_64-unknown-linux-gnu
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: 'recursive'
-    - name: Install Rust (rustup)
-      run: rustup update stable --no-self-update && rustup default stable && rustup target add ${{ matrix.target }}
-      shell: bash
-    - name: Install golang
-      uses: actions/setup-go@v5
-      with:
-        go-version: '>=1.22.0'
-    - name: Install ${{ matrix.target }} toolchain
-      run: brew tap messense/macos-cross-toolchains && brew install ${{ matrix.target }} && brew link x86_64-unknown-linux-gnu
-    - name: Install Clang-12
-      uses: KyleMayes/install-llvm-action@v1
-      with:
-        version: "12.0.0"
-        directory: ${{ runner.temp }}/llvm
-    - name: Add clang++-12 link
-      working-directory: ${{ runner.temp }}/llvm/bin
-      run: ln -s clang++ clang++-12
-    - name: Set BORING_BSSL_FIPS_COMPILER_EXTERNAL_TOOLCHAIN
-      run: echo "BORING_BSSL_FIPS_COMPILER_EXTERNAL_TOOLCHAIN=$(brew --prefix ${{ matrix.target }})/toolchain" >> $GITHUB_ENV
-      shell: bash
-    - name: Set BORING_BSSL_FIPS_SYSROOT
-      run: echo "BORING_BSSL_FIPS_SYSROOT=$BORING_BSSL_FIPS_COMPILER_EXTERNAL_TOOLCHAIN/${{ matrix.target }}/sysroot" >> $GITHUB_ENV
-      shell: bash
-    - name: Set CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER
-      run: echo "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=${{ matrix.target }}-gcc" >> $GITHUB_ENV
-    - name: Build for ${{ matrix.target }}
-      run: cargo build --target ${{ matrix.target }} --all-targets --features fips
-
   test-features:
     name: Test features
     runs-on: ubuntu-latest


### PR DESCRIPTION
GitHub has dropped support for old Intel macOS builders. Building on a new ARM macOS boxes fails to link libc++ symbols, presumably because the ABI has changed since clang-12.

We can try restoring this when we upgrade boringssl to the new fips version with a less stale clang, but for now I'd like to unblock the CI.
