### PR TITLE
Deprecate set_ex_data on v4

### DIFF
--- a/boring/src/ssl/test/mod.rs
+++ b/boring/src/ssl/test/mod.rs
@@ -1166,3 +1166,47 @@ fn test_ssl_set_compliance() {
     ssl.set_compliance_policy(CompliancePolicy::NONE)
         .expect_err("Testing expect err if set compliance policy to NONE");
 }
+
+#[test]
+#[allow(deprecated)]
+fn ex_data_drop() {
+    use crate::ssl::SslContextBuilder;
+    use std::sync::atomic::AtomicU32;
+    use std::sync::atomic::Ordering::Relaxed;
+    use std::sync::Arc;
+
+    struct TrackDrop(Arc<AtomicU32>);
+    impl Drop for TrackDrop {
+        fn drop(&mut self) {
+            self.0.fetch_add(1, Relaxed);
+        }
+    }
+
+    let mut ctx = SslContextBuilder::new(SslMethod::tls()).unwrap();
+    let index = SslContext::new_ex_index().unwrap();
+    let d1 = Arc::new(AtomicU32::new(100));
+    let d2 = Arc::new(AtomicU32::new(200));
+    let d3 = Arc::new(AtomicU32::new(300));
+    ctx.set_ex_data(index, TrackDrop(d1.clone()));
+    assert_eq!(100, d1.load(Relaxed));
+    assert_eq!(200, d2.load(Relaxed));
+    ctx.replace_ex_data(index, TrackDrop(d2.clone()));
+    assert_eq!(101, d1.load(Relaxed));
+    assert_eq!(200, d2.load(Relaxed));
+    ctx.replace_ex_data(index, TrackDrop(d3.clone()));
+    assert_eq!(101, d1.load(Relaxed));
+    assert_eq!(201, d2.load(Relaxed));
+    assert_eq!(300, d3.load(Relaxed));
+    drop(ctx);
+    assert_eq!(101, d1.load(Relaxed));
+    assert_eq!(201, d2.load(Relaxed));
+    assert_eq!(301, d3.load(Relaxed));
+
+    let mut ctx2 = SslContextBuilder::new(SslMethod::tls()).unwrap();
+
+    ctx2.set_ex_data(index, TrackDrop(d1.clone()));
+    ctx2.set_ex_data(index, TrackDrop(d2.clone()));
+    drop(ctx2);
+    assert_eq!(101, d1.load(Relaxed), "set_ex_data has a leak");
+    assert_eq!(202, d2.load(Relaxed));
+}

--- a/boring/src/x509/mod.rs
+++ b/boring/src/x509/mod.rs
@@ -132,6 +132,7 @@ impl X509StoreContextRef {
     /// This can be used to provide data to callbacks registered with the context. Use the
     /// `Ssl::new_ex_index` method to create an `Index`.
     #[corresponds(X509_STORE_CTX_set_ex_data)]
+    #[doc(alias = "replace_ex_data")]
     pub fn set_ex_data<T>(&mut self, index: Index<X509StoreContext, T>, data: T) {
         if let Some(old) = self.ex_data_mut(index) {
             *old = data;


### PR DESCRIPTION
v5 plans to change behavior of the function (#196), so it'd be nice to warn about the change on v4 first.