### PR TITLE
Fix non-additive feature on set_curves_list

### DIFF
--- a/boring/src/ssl/mod.rs
+++ b/boring/src/ssl/mod.rs
@@ -2052,11 +2052,6 @@ impl SslContextBuilder {
     }
 
     /// Sets the context's supported curves.
-    //
-    // If the "kx-*" flags are used to set key exchange preference, then don't allow the user to
-    // set them here. This ensures we don't override the user's preference without telling them:
-    // when the flags are used, the preferences are set just before connecting or accepting.
-    #[cfg(not(feature = "kx-safe-default"))]
     #[corresponds(SSL_CTX_set1_curves_list)]
     pub fn set_curves_list(&mut self, curves: &str) -> Result<(), ErrorStack> {
         let curves = CString::new(curves).map_err(ErrorStack::internal_error)?;


### PR DESCRIPTION
Cargo features are supposed to be additive, so this was an incorrect usage. It made set_curves_list impossible to use in libraries, because a library using boring doesn't control what other features other crates may set.

The kx-* features have already been removed in v5.