### PR TITLE
Remove blanket Eq from FFI types

### DIFF
--- a/boring-sys/build/main.rs
+++ b/boring-sys/build/main.rs
@@ -637,7 +637,8 @@ fn generate_bindings(config: &Config) {
         .derive_copy(true)
         .derive_debug(true)
         .derive_default(true)
-        .derive_eq(true)
+        .derive_eq(false)
+        .derive_partialeq(false)
         .default_enum_style(bindgen::EnumVariation::NewType {
             is_bitfield: false,
             is_global: false,

--- a/boring-sys/src/lib.rs
+++ b/boring-sys/src/lib.rs
@@ -20,7 +20,6 @@ use std::os::raw::{c_char, c_int, c_uint, c_ulong};
     clippy::useless_transmute,
     clippy::derive_partial_eq_without_eq,
     clippy::ptr_offset_with_cast,
-    unpredictable_function_pointer_comparisons, // TODO: remove Eq/PartialEq in v5
     dead_code
 )]
 mod generated {


### PR DESCRIPTION
Rust's equality of foreign types is questionable. This is technically a breaking change, but the implementations weren't used by us anywhere.
