### PR TITLE
Safer slices

### DIFF
--- a/boring/src/pkey.rs
+++ b/boring/src/pkey.rs
@@ -235,7 +235,7 @@ where
     pub fn raw_public_key_len(&self) -> Result<usize, ErrorStack> {
         unsafe {
             let mut size = 0;
-            _ = cvt_0i(ffi::EVP_PKEY_get_raw_public_key(
+            cvt_0i(ffi::EVP_PKEY_get_raw_public_key(
                 self.as_ptr(),
                 std::ptr::null_mut(),
                 &mut size,
@@ -251,7 +251,7 @@ where
     pub fn raw_public_key<'a>(&self, out: &'a mut [u8]) -> Result<&'a [u8], ErrorStack> {
         unsafe {
             let mut size = out.len();
-            _ = cvt_0i(ffi::EVP_PKEY_get_raw_public_key(
+            cvt_0i(ffi::EVP_PKEY_get_raw_public_key(
                 self.as_ptr(),
                 out.as_mut_ptr(),
                 &mut size,
@@ -303,7 +303,7 @@ where
     pub fn raw_private_key_len(&self) -> Result<usize, ErrorStack> {
         unsafe {
             let mut size = 0;
-            _ = cvt_0i(ffi::EVP_PKEY_get_raw_private_key(
+            cvt_0i(ffi::EVP_PKEY_get_raw_private_key(
                 self.as_ptr(),
                 std::ptr::null_mut(),
                 &mut size,
@@ -319,7 +319,7 @@ where
     pub fn raw_private_key<'a>(&self, out: &'a mut [u8]) -> Result<&'a [u8], ErrorStack> {
         unsafe {
             let mut size = out.len();
-            _ = cvt_0i(ffi::EVP_PKEY_get_raw_private_key(
+            cvt_0i(ffi::EVP_PKEY_get_raw_private_key(
                 self.as_ptr(),
                 out.as_mut_ptr(),
                 &mut size,

--- a/boring/src/util.rs
+++ b/boring/src/util.rs
@@ -1,9 +1,9 @@
 use crate::error::ErrorStack;
+use crate::try_slice_mut;
 use foreign_types::{ForeignType, ForeignTypeRef};
 use libc::{c_char, c_int, c_void};
 use std::any::Any;
 use std::panic::{self, AssertUnwindSafe};
-use std::slice;
 
 /// Wraps a user-supplied callback and a slot for panics thrown inside the callback (while FFI
 /// frames are on the stack).
@@ -49,7 +49,7 @@ where
     let callback = &mut *cb_state.cast::<CallbackState<F>>();
 
     let result = panic::catch_unwind(AssertUnwindSafe(|| {
-        let pass_slice = slice::from_raw_parts_mut(buf.cast::<u8>(), size as usize);
+        let pass_slice = try_slice_mut(buf.cast::<u8>(), size)?;
         callback.cb.take().unwrap()(pass_slice)
     }));
 


### PR DESCRIPTION
Helper functions that remove boilerplate `is_null` and length checks for slices. It also guards against UB and costs just 3 `cmove`s on x86.

There are a few `from_raw_parts` left in callbacks, but making these nicer needs wrapping them in a `Result`-returning functions first. 