### PR TITLE
Use CC/CXX override only if there's no toolchain file

### DIFF
--- a/boring-sys/build/config.rs
+++ b/boring-sys/build/config.rs
@@ -33,7 +33,7 @@ pub(crate) struct Env {
     pub(crate) debug: Option<OsString>,
     pub(crate) opt_level: Option<OsString>,
     pub(crate) android_ndk_home: Option<PathBuf>,
-    pub(crate) cmake_toolchain_file: Option<PathBuf>,
+    pub(crate) cmake_toolchain_file_is_set: bool,
     pub(crate) cpp_runtime_lib: Option<OsString>,
     /// C compiler (ignored if using FIPS)
     pub(crate) cc: Option<OsString>,
@@ -160,7 +160,7 @@ impl Env {
 
             // The passed name is the non-fips version of the environment variable,
             // to help look for them in the repository.
-            assert!(name.starts_with(BORING_BSSL_PREFIX));
+            debug_assert!(name.starts_with(BORING_BSSL_PREFIX));
 
             let non_fips = target_var(name);
             if is_fips_like {
@@ -181,13 +181,15 @@ impl Env {
             source_path: boringssl_var("BORING_BSSL_SOURCE_PATH").map(PathBuf::from), // gets BORING_BSSL_FIPS_SOURCE_PATH if fips is enabled
             assume_patched: boringssl_var("BORING_BSSL_ASSUME_PATCHED") // gets BORING_BSSL_FIPS_ASSUME_PATCHED if fips is enabled
                 .is_some_and(|v| !v.is_empty()),
+            // only used when cross-compiling
             sysroot: boringssl_var("BORING_BSSL_SYSROOT").map(PathBuf::from), // gets BORING_BSSL_FIPS_SYSROOT if fips is enabled
+            // only used when cross-compiling
             compiler_external_toolchain: boringssl_var("BORING_BSSL_COMPILER_EXTERNAL_TOOLCHAIN") // gets BORING_BSSL_FIPS_COMPILER_EXTERNAL_TOOLCHAIN if fips is enabled
                 .map(PathBuf::from),
             debug: target_var("DEBUG"),
             opt_level: target_var("OPT_LEVEL"),
             android_ndk_home: target_var("ANDROID_NDK_HOME").map(Into::into),
-            cmake_toolchain_file: target_var("CMAKE_TOOLCHAIN_FILE").map(Into::into),
+            cmake_toolchain_file_is_set: var("CMAKE_TOOLCHAIN_FILE").is_some(),
             cpp_runtime_lib: target_var("BORING_BSSL_RUST_CPPLIB"),
             // matches the `cc` crate
             cc: target_only_var("CC"),

--- a/boring-sys/build/config.rs
+++ b/boring-sys/build/config.rs
@@ -191,7 +191,7 @@ impl Env {
             android_ndk_home: target_var("ANDROID_NDK_HOME").map(Into::into),
             cmake_toolchain_file_is_set: var("CMAKE_TOOLCHAIN_FILE").is_some(),
             cpp_runtime_lib: target_var("BORING_BSSL_RUST_CPPLIB"),
-            // matches the `cc` crate
+            // matches the `cc` crate. Not used when fips is enabled or cmake toolchain is set
             cc: target_only_var("CC"),
             cxx: target_only_var("CXX"),
             docs_rs: var("DOCS_RS").is_some(),

--- a/boring-sys/build/main.rs
+++ b/boring-sys/build/main.rs
@@ -204,7 +204,8 @@ fn get_boringssl_cmake_config(config: &Config) -> cmake::Config {
     let src_path = get_boringssl_source_path(config);
     let mut boringssl_cmake = cmake::Config::new(src_path);
 
-    if config.env.cmake_toolchain_file.is_some() {
+    if config.env.cmake_toolchain_file_is_set {
+        println!("cargo::warning=CMAKE_TOOLCHAIN_FILE var set; won't customize cmake vars");
         return boringssl_cmake;
     }
 
@@ -213,14 +214,18 @@ fn get_boringssl_cmake_config(config: &Config) -> cmake::Config {
         // This is required now because newest BoringSSL requires CMake 3.22 which
         // uses the new logic with CMAKE_MSVC_RUNTIME_LIBRARY introduced in CMake 3.15.
         // https://github.com/rust-lang/cmake-rs/pull/30#issuecomment-2969758499
-        if config.target_features.iter().any(|f| f == "crt-static") {
-            boringssl_cmake.define("CMAKE_MSVC_RUNTIME_LIBRARY", "MultiThreaded");
+        let rt = if config.target_features.iter().any(|f| f == "crt-static") {
+            "MultiThreaded"
         } else {
-            boringssl_cmake.define("CMAKE_MSVC_RUNTIME_LIBRARY", "MultiThreadedDLL");
-        }
+            "MultiThreadedDLL"
+        };
+        boringssl_cmake.define("CMAKE_MSVC_RUNTIME_LIBRARY", rt);
     }
 
     if config.host == config.target {
+        if config.env.compiler_external_toolchain.is_some() {
+            println!("cargo::warning=COMPILER_EXTERNAL_TOOLCHAIN won't be used");
+        }
         return boringssl_cmake;
     }
 
@@ -253,7 +258,7 @@ fn get_boringssl_cmake_config(config: &Config) -> cmake::Config {
     }
 
     // Add platform-specific parameters for cross-compilation.
-    match &*config.target_os {
+    let toolchain_file = match &*config.target_os {
         "android" => {
             // We need ANDROID_NDK_HOME to be set properly.
             let android_ndk_home = config
@@ -266,68 +271,44 @@ fn get_boringssl_cmake_config(config: &Config) -> cmake::Config {
                 boringssl_cmake.define(name, value);
             }
             let toolchain_file = android_ndk_home.join("build/cmake/android.toolchain.cmake");
-            let toolchain_file = toolchain_file.to_str().unwrap();
-            eprintln!("android toolchain={toolchain_file}");
-            boringssl_cmake.define("CMAKE_TOOLCHAIN_FILE", toolchain_file);
 
             // 21 is the minimum level tested. You can give higher value.
             boringssl_cmake.define("CMAKE_SYSTEM_VERSION", "21");
             boringssl_cmake.define("CMAKE_ANDROID_STL_TYPE", "c++_shared");
+            Some(toolchain_file)
         }
-
         os @ ("macos" | "ios") => {
             for (name, value) in cmake_params_apple(config) {
                 eprintln!("{os} arch={} add {}={}", config.target_arch, name, value);
                 boringssl_cmake.define(name, value);
             }
+            None
         }
-
         "windows" if config.host.contains("windows") => {
             // BoringSSL's CMakeLists.txt isn't set up for cross-compiling using Visual Studio.
             // Disable assembly support so that it at least builds.
             boringssl_cmake.define("OPENSSL_NO_ASM", "YES");
+            None
         }
-
         "linux" => match &*config.target_arch {
-            "x86" => {
-                boringssl_cmake.define(
-                    "CMAKE_TOOLCHAIN_FILE",
-                    // `src_path` can be a path relative to the manifest dir, but
-                    // cmake hates that.
-                    config
-                        .manifest_dir
-                        .join(src_path)
-                        .join("util/32-bit-toolchain.cmake")
-                        .as_os_str(),
-                );
-            }
-            "aarch64" => {
-                boringssl_cmake.define(
-                    "CMAKE_TOOLCHAIN_FILE",
-                    config
-                        .manifest_dir
-                        .join("cmake/aarch64-linux.cmake")
-                        .as_os_str(),
-                );
-            }
-            "arm" => {
-                boringssl_cmake.define(
-                    "CMAKE_TOOLCHAIN_FILE",
-                    config
-                        .manifest_dir
-                        .join("cmake/armv7-linux.cmake")
-                        .as_os_str(),
-                );
-            }
-            _ => {
-                println!(
-                    "cargo:warning=no toolchain file configured by boring-sys for {}",
-                    config.target
-                );
-            }
+            "x86" => Some(
+                config
+                    .manifest_dir
+                    .join(src_path)
+                    .join("util/32-bit-toolchain.cmake"),
+            ),
+            "aarch64" => Some(config.manifest_dir.join("cmake/aarch64-linux.cmake")),
+            "arm" => Some(config.manifest_dir.join("cmake/armv7-linux.cmake")),
+            _ => None,
         },
+        _ => None,
+    };
 
-        _ => {}
+    if let Some(tf) = toolchain_file {
+        eprintln!("{} toolchain={}", config.target_os, tf.display());
+        boringssl_cmake.define("CMAKE_TOOLCHAIN_FILE", tf);
+    } else {
+        println!("cargo:warning=no toolchain file set for {}", config.target);
     }
 
     boringssl_cmake

--- a/boring-sys/build/main.rs
+++ b/boring-sys/build/main.rs
@@ -44,13 +44,13 @@ fn cmake_params_android(config: &Config) -> &'static [(&'static str, &'static st
 }
 
 const CMAKE_PARAMS_APPLE: &[(&str, &[(&str, &str)])] = &[
-    // iOS
     (
         "aarch64-apple-ios",
         &[
             ("CMAKE_OSX_ARCHITECTURES", "arm64"),
             ("CMAKE_OSX_SYSROOT", "iphoneos"),
             ("CMAKE_MACOSX_BUNDLE", "OFF"),
+            ("CMAKE_ASM_FLAGS", "-fembed-bitcode"),
         ],
     ),
     (
@@ -59,6 +59,7 @@ const CMAKE_PARAMS_APPLE: &[(&str, &[(&str, &str)])] = &[
             ("CMAKE_OSX_ARCHITECTURES", "arm64"),
             ("CMAKE_OSX_SYSROOT", "iphonesimulator"),
             ("CMAKE_MACOSX_BUNDLE", "OFF"),
+            ("CMAKE_ASM_FLAGS", "-fembed-bitcode"),
         ],
     ),
     (
@@ -67,9 +68,12 @@ const CMAKE_PARAMS_APPLE: &[(&str, &[(&str, &str)])] = &[
             ("CMAKE_OSX_ARCHITECTURES", "x86_64"),
             ("CMAKE_OSX_SYSROOT", "iphonesimulator"),
             ("CMAKE_MACOSX_BUNDLE", "OFF"),
+            (
+                "CMAKE_ASM_FLAGS",
+                "-fembed-bitcode -target x86_64-apple-ios-simulator",
+            ),
         ],
     ),
-    // macOS
     (
         "aarch64-apple-darwin",
         &[
@@ -87,25 +91,16 @@ const CMAKE_PARAMS_APPLE: &[(&str, &[(&str, &str)])] = &[
 ];
 
 fn cmake_params_apple(config: &Config) -> &'static [(&'static str, &'static str)] {
-    for (next_target, params) in CMAKE_PARAMS_APPLE {
-        if *next_target == config.target {
-            return params;
-        }
-    }
-    &[]
+    CMAKE_PARAMS_APPLE
+        .iter()
+        .find_map(|&(target, params)| (target == config.target).then_some(params))
+        .unwrap_or_default()
 }
 
-fn get_apple_sdk_name(config: &Config) -> &'static str {
-    for (name, value) in cmake_params_apple(config) {
-        if *name == "CMAKE_OSX_SYSROOT" {
-            return value;
-        }
-    }
-
-    panic!(
-        "cannot find SDK for {} in CMAKE_PARAMS_APPLE",
-        config.target
-    );
+fn get_apple_sdk_name(config: &Config) -> Option<&'static str> {
+    cmake_params_apple(config)
+        .iter()
+        .find_map(|&(name, value)| (name == "CMAKE_OSX_SYSROOT").then_some(value))
 }
 
 /// Returns an absolute path to the BoringSSL source.
@@ -280,32 +275,11 @@ fn get_boringssl_cmake_config(config: &Config) -> cmake::Config {
             boringssl_cmake.define("CMAKE_ANDROID_STL_TYPE", "c++_shared");
         }
 
-        "macos" => {
+        os @ ("macos" | "ios") => {
             for (name, value) in cmake_params_apple(config) {
-                eprintln!("macos arch={} add {}={}", config.target_arch, name, value);
+                eprintln!("{os} arch={} add {}={}", config.target_arch, name, value);
                 boringssl_cmake.define(name, value);
             }
-        }
-
-        "ios" => {
-            for (name, value) in cmake_params_apple(config) {
-                eprintln!("ios arch={} add {}={}", config.target_arch, name, value);
-                boringssl_cmake.define(name, value);
-            }
-
-            // Bitcode is always on.
-            let bitcode_cflag = "-fembed-bitcode";
-
-            // Hack for Xcode 10.1.
-            let target_cflag = if config.target_arch == "x86_64" {
-                "-target x86_64-apple-ios-simulator"
-            } else {
-                ""
-            };
-
-            let cflag = format!("{bitcode_cflag} {target_cflag}");
-            boringssl_cmake.define("CMAKE_ASM_FLAGS", &cflag);
-            boringssl_cmake.cflag(&cflag);
         }
 
         "windows" if config.host.contains("windows") => {
@@ -394,8 +368,11 @@ fn get_extra_clang_args_for_bindgen(config: &Config) -> Vec<String> {
         "ios" | "macos" => {
             // When cross-compiling for Apple targets, tell bindgen to use SDK sysroot,
             // and *don't* use system headers of the host macOS.
-            let sdk = get_apple_sdk_name(config);
-            match run_command(Command::new("xcrun").args(["--show-sdk-path", "--sdk", sdk])) {
+            match get_apple_sdk_name(config)
+                .ok_or_else(|| io::Error::other(format!("can't find SDK for {}", config.target)))
+                .and_then(|sdk| {
+                    run_command(Command::new("xcrun").args(["--show-sdk-path", "--sdk", sdk]))
+                }) {
                 Ok(output) => {
                     let sysroot = std::str::from_utf8(&output.stdout).expect("xcrun output");
                     params.push("-isysroot".to_string());

--- a/boring-sys/build/main.rs
+++ b/boring-sys/build/main.rs
@@ -237,15 +237,6 @@ fn get_boringssl_cmake_config(config: &Config) -> cmake::Config {
             .define("CMAKE_ASM_COMPILER_TARGET", &config.target);
     }
 
-    if !config.features.fips {
-        if let Some(cc) = &config.env.cc {
-            boringssl_cmake.define("CMAKE_C_COMPILER", cc);
-        }
-        if let Some(cxx) = &config.env.cxx {
-            boringssl_cmake.define("CMAKE_CXX_COMPILER", cxx);
-        }
-    }
-
     if let Some(sysroot) = &config.env.sysroot {
         boringssl_cmake.define("CMAKE_SYSROOT", sysroot);
     }
@@ -304,11 +295,19 @@ fn get_boringssl_cmake_config(config: &Config) -> cmake::Config {
         _ => None,
     };
 
-    if let Some(tf) = toolchain_file {
+    if let Some(tf) = toolchain_file.filter(|tf| tf.exists()) {
         eprintln!("{} toolchain={}", config.target_os, tf.display());
         boringssl_cmake.define("CMAKE_TOOLCHAIN_FILE", tf);
     } else {
         println!("cargo:warning=no toolchain file set for {}", config.target);
+        if !config.features.fips {
+            if let Some(cc) = &config.env.cc {
+                boringssl_cmake.define("CMAKE_C_COMPILER", cc);
+            }
+            if let Some(cxx) = &config.env.cxx {
+                boringssl_cmake.define("CMAKE_CXX_COMPILER", cxx);
+            }
+        }
     }
 
     boringssl_cmake


### PR DESCRIPTION
`CC_{target}` is used only as a fallback, assuming that cmake toolchain files know better.

Code cleanups in separate commits.