### PR TITLE
unsafe_op_in_unsafe_fn

### DIFF
--- a/boring/src/lib.rs
+++ b/boring/src/lib.rs
@@ -223,6 +223,8 @@ unsafe extern "C" fn free_data_box<T>(
     _argp: *mut c_void,
 ) {
     if !ptr.is_null() {
-        drop(Box::<T>::from_raw(ptr.cast::<T>()));
+        unsafe {
+            drop(Box::<T>::from_raw(ptr.cast::<T>()));
+        }
     }
 }

--- a/boring/src/ssl/async_callbacks.rs
+++ b/boring/src/ssl/async_callbacks.rs
@@ -148,7 +148,9 @@ impl SslContextBuilder {
             }
         };
 
-        self.set_get_session_callback(async_callback);
+        unsafe {
+            self.set_get_session_callback(async_callback);
+        }
     }
 
     /// Configures certificate verification.

--- a/boring/src/ssl/bio.rs
+++ b/boring/src/ssl/bio.rs
@@ -52,100 +52,113 @@ pub fn new<S: Read + Write>(stream: S) -> Result<(*mut BIO, BioMethod), ErrorSta
 }
 
 pub unsafe fn take_error<S>(bio: *mut BIO) -> Option<io::Error> {
-    let state = state::<S>(bio);
-    state.error.take()
+    unsafe {
+        let state = state::<S>(bio);
+        state.error.take()
+    }
 }
 
 pub unsafe fn take_panic<S>(bio: *mut BIO) -> Option<Box<dyn Any + Send>> {
-    let state = state::<S>(bio);
-    state.panic.take()
+    unsafe {
+        let state = state::<S>(bio);
+        state.panic.take()
+    }
 }
 
 pub unsafe fn get_ref<'a, S: 'a>(bio: *mut BIO) -> &'a S {
-    &state(bio).stream
+    unsafe { &state(bio).stream }
 }
 
 pub unsafe fn get_mut<'a, S: 'a>(bio: *mut BIO) -> &'a mut S {
-    &mut state(bio).stream
+    unsafe { &mut state(bio).stream }
 }
 
 pub unsafe extern "C" fn take_stream<S>(bio: *mut BIO) -> S {
     assert!(!bio.is_null());
+    unsafe {
+        let data = BIO_get_data(bio);
 
-    let data = BIO_get_data(bio);
+        assert!(!data.is_null());
 
-    assert!(!data.is_null());
+        let state = Box::<StreamState<S>>::from_raw(data.cast());
 
-    let state = Box::<StreamState<S>>::from_raw(data.cast());
+        BIO_set_data(bio, ptr::null_mut());
 
-    BIO_set_data(bio, ptr::null_mut());
-
-    state.stream
+        state.stream
+    }
 }
 
 pub unsafe fn set_dtls_mtu_size<S>(bio: *mut BIO, mtu_size: usize) {
-    if mtu_size as u64 > c_long::MAX as u64 {
-        panic!("Given MTU size {mtu_size} can't be represented in a positive `c_long` range")
+    unsafe {
+        if mtu_size as u64 > c_long::MAX as u64 {
+            panic!("Given MTU size {mtu_size} can't be represented in a positive `c_long` range")
+        }
+        state::<S>(bio).dtls_mtu_size = mtu_size as c_long;
     }
-    state::<S>(bio).dtls_mtu_size = mtu_size as c_long;
 }
 
 unsafe fn state<'a, S: 'a>(bio: *mut BIO) -> &'a mut StreamState<S> {
-    let data = BIO_get_data(bio).cast::<StreamState<S>>();
+    unsafe {
+        let data = BIO_get_data(bio).cast::<StreamState<S>>();
 
-    assert!(!data.is_null());
+        assert!(!data.is_null());
 
-    &mut *data
+        &mut *data
+    }
 }
 
 unsafe extern "C" fn bwrite<S: Write>(bio: *mut BIO, buf: *const c_char, len: c_int) -> c_int {
-    BIO_clear_retry_flags(bio);
+    unsafe {
+        BIO_clear_retry_flags(bio);
 
-    let Ok(len) = usize::try_from(len) else {
-        return -1;
-    };
+        let Ok(len) = usize::try_from(len) else {
+            return -1;
+        };
 
-    let state = state::<S>(bio);
-    let buf = slice::from_raw_parts(buf.cast(), len);
+        let state = state::<S>(bio);
+        let buf = slice::from_raw_parts(buf.cast(), len);
 
-    match catch_unwind(AssertUnwindSafe(|| state.stream.write(buf))) {
-        Ok(Ok(len)) => len as c_int,
-        Ok(Err(err)) => {
-            if retriable_error(&err) {
-                BIO_set_retry_write(bio);
+        match catch_unwind(AssertUnwindSafe(|| state.stream.write(buf))) {
+            Ok(Ok(len)) => len as c_int,
+            Ok(Err(err)) => {
+                if retriable_error(&err) {
+                    BIO_set_retry_write(bio);
+                }
+                state.error = Some(err);
+                -1
             }
-            state.error = Some(err);
-            -1
-        }
-        Err(err) => {
-            state.panic = Some(err);
-            -1
+            Err(err) => {
+                state.panic = Some(err);
+                -1
+            }
         }
     }
 }
 
 unsafe extern "C" fn bread<S: Read>(bio: *mut BIO, buf: *mut c_char, len: c_int) -> c_int {
-    BIO_clear_retry_flags(bio);
+    unsafe {
+        BIO_clear_retry_flags(bio);
 
-    let Ok(len) = usize::try_from(len) else {
-        return -1;
-    };
+        let Ok(len) = usize::try_from(len) else {
+            return -1;
+        };
 
-    let state = state::<S>(bio);
-    let buf = slice::from_raw_parts_mut(buf.cast(), len);
+        let state = state::<S>(bio);
+        let buf = slice::from_raw_parts_mut(buf.cast(), len);
 
-    match catch_unwind(AssertUnwindSafe(|| state.stream.read(buf))) {
-        Ok(Ok(len)) => len as c_int,
-        Ok(Err(err)) => {
-            if retriable_error(&err) {
-                BIO_set_retry_read(bio);
+        match catch_unwind(AssertUnwindSafe(|| state.stream.read(buf))) {
+            Ok(Ok(len)) => len as c_int,
+            Ok(Err(err)) => {
+                if retriable_error(&err) {
+                    BIO_set_retry_read(bio);
+                }
+                state.error = Some(err);
+                -1
             }
-            state.error = Some(err);
-            -1
-        }
-        Err(err) => {
-            state.panic = Some(err);
-            -1
+            Err(err) => {
+                state.panic = Some(err);
+                -1
+            }
         }
     }
 }
@@ -159,7 +172,7 @@ fn retriable_error(err: &io::Error) -> bool {
 }
 
 unsafe extern "C" fn bputs<S: Write>(bio: *mut BIO, s: *const c_char) -> c_int {
-    bwrite::<S>(bio, s, strlen(s) as c_int)
+    unsafe { bwrite::<S>(bio, s, strlen(s) as c_int) }
 }
 
 unsafe extern "C" fn ctrl<S: Write>(
@@ -168,37 +181,41 @@ unsafe extern "C" fn ctrl<S: Write>(
     _num: c_long,
     _ptr: *mut c_void,
 ) -> c_long {
-    let state = state::<S>(bio);
+    unsafe {
+        let state = state::<S>(bio);
 
-    if cmd == BIO_CTRL_FLUSH {
-        BIO_clear_retry_flags(bio);
-        match catch_unwind(AssertUnwindSafe(|| state.stream.flush())) {
-            Ok(Ok(())) => 1,
-            Ok(Err(err)) => {
-                if retriable_error(&err) {
-                    BIO_set_retry_write(bio);
+        if cmd == BIO_CTRL_FLUSH {
+            BIO_clear_retry_flags(bio);
+            match catch_unwind(AssertUnwindSafe(|| state.stream.flush())) {
+                Ok(Ok(())) => 1,
+                Ok(Err(err)) => {
+                    if retriable_error(&err) {
+                        BIO_set_retry_write(bio);
+                    }
+                    state.error = Some(err);
+                    0
                 }
-                state.error = Some(err);
-                0
+                Err(err) => {
+                    state.panic = Some(err);
+                    0
+                }
             }
-            Err(err) => {
-                state.panic = Some(err);
-                0
-            }
+        } else if cmd == BIO_CTRL_DGRAM_QUERY_MTU {
+            state.dtls_mtu_size
+        } else {
+            0
         }
-    } else if cmd == BIO_CTRL_DGRAM_QUERY_MTU {
-        state.dtls_mtu_size
-    } else {
-        0
     }
 }
 
 unsafe extern "C" fn create(bio: *mut BIO) -> c_int {
-    BIO_set_init(bio, 0);
-    BIO_set_num(bio, 0);
-    BIO_set_data(bio, ptr::null_mut());
-    BIO_set_flags(bio, 0);
-    1
+    unsafe {
+        BIO_set_init(bio, 0);
+        BIO_set_num(bio, 0);
+        BIO_set_data(bio, ptr::null_mut());
+        BIO_set_flags(bio, 0);
+        1
+    }
 }
 
 unsafe extern "C" fn destroy<S>(bio: *mut BIO) -> c_int {
@@ -206,15 +223,17 @@ unsafe extern "C" fn destroy<S>(bio: *mut BIO) -> c_int {
         return 0;
     }
 
-    let data = BIO_get_data(bio);
+    unsafe {
+        let data = BIO_get_data(bio);
 
-    if !data.is_null() {
-        drop(Box::<StreamState<S>>::from_raw(data.cast()));
-        BIO_set_data(bio, ptr::null_mut());
+        if !data.is_null() {
+            drop(Box::<StreamState<S>>::from_raw(data.cast()));
+            BIO_set_data(bio, ptr::null_mut());
+        }
+
+        BIO_set_init(bio, 0);
+        1
     }
-
-    BIO_set_init(bio, 0);
-    1
 }
 
 use crate::ffi::{BIO_get_data, BIO_set_data, BIO_set_flags, BIO_set_init};

--- a/boring/src/ssl/ech.rs
+++ b/boring/src/ssl/ech.rs
@@ -22,7 +22,7 @@ impl SslEchKeysBuilder {
 
     pub unsafe fn from_ptr(keys: *mut ffi::SSL_ECH_KEYS) -> Self {
         Self {
-            keys: SslEchKeys::from_ptr(keys),
+            keys: unsafe { SslEchKeys::from_ptr(keys) },
         }
     }
 

--- a/boring/src/ssl/mod.rs
+++ b/boring/src/ssl/mod.rs
@@ -951,7 +951,7 @@ impl SslContextBuilder {
     /// The context must own its cert store exclusively.
     pub unsafe fn from_ptr(ctx: *mut ffi::SSL_CTX) -> Self {
         Self {
-            ctx: SslContext::from_ptr(ctx),
+            ctx: unsafe { SslContext::from_ptr(ctx) },
             has_shared_cert_store: false,
         }
     }
@@ -964,7 +964,9 @@ impl SslContextBuilder {
     /// X.509 certificates with an object configured with this method.
     /// You most probably don't need it.
     pub unsafe fn assume_x509(&mut self) {
-        self.ctx.assume_x509();
+        unsafe {
+            self.ctx.assume_x509();
+        }
     }
 
     /// Returns a pointer to the raw OpenSSL value.
@@ -1882,7 +1884,9 @@ impl SslContextBuilder {
             + Send,
     {
         self.replace_ex_data(SslContext::cached_ex_index::<F>(), callback);
-        ffi::SSL_CTX_sess_set_get_cb(self.as_ptr(), Some(callbacks::raw_get_session::<F>));
+        unsafe {
+            ffi::SSL_CTX_sess_set_get_cb(self.as_ptr(), Some(callbacks::raw_get_session::<F>));
+        }
     }
 
     /// Sets the TLS key logging callback.
@@ -2236,9 +2240,11 @@ impl SslContextRef {
     // this only from SslContextBuilder.
     #[corresponds(SSL_CTX_get_ex_data)]
     unsafe fn ex_data_mut<T>(&mut self, index: Index<SslContext, T>) -> Option<&mut T> {
-        ffi::SSL_CTX_get_ex_data(self.as_ptr(), index.as_raw())
-            .cast::<T>()
-            .as_mut()
+        unsafe {
+            ffi::SSL_CTX_get_ex_data(self.as_ptr(), index.as_raw())
+                .cast::<T>()
+                .as_mut()
+        }
     }
 
     // Unsafe because SSL contexts are not guaranteed to be unique, we call
@@ -2255,13 +2261,15 @@ impl SslContextRef {
     // this only from SslContextBuilder.
     #[corresponds(SSL_CTX_set_ex_data)]
     unsafe fn replace_ex_data<T>(&mut self, index: Index<SslContext, T>, data: T) -> Option<T> {
-        if let Some(old) = self.ex_data_mut(index) {
-            return Some(mem::replace(old, data));
+        unsafe {
+            if let Some(old) = self.ex_data_mut(index) {
+                return Some(mem::replace(old, data));
+            }
+
+            self.set_ex_data(index, data);
+
+            None
         }
-
-        self.set_ex_data(index, data);
-
-        None
     }
 
     /// Adds a session to the context's cache.
@@ -2275,7 +2283,7 @@ impl SslContextRef {
     #[corresponds(SSL_CTX_add_session)]
     #[must_use]
     pub unsafe fn add_session(&self, session: &SslSessionRef) -> bool {
-        ffi::SSL_CTX_add_session(self.as_ptr(), session.as_ptr()) != 0
+        unsafe { ffi::SSL_CTX_add_session(self.as_ptr(), session.as_ptr()) != 0 }
     }
 
     /// Removes a session from the context's cache and marks it as non-resumable.
@@ -2289,7 +2297,7 @@ impl SslContextRef {
     #[corresponds(SSL_CTX_remove_session)]
     #[must_use]
     pub unsafe fn remove_session(&self, session: &SslSessionRef) -> bool {
-        ffi::SSL_CTX_remove_session(self.as_ptr(), session.as_ptr()) != 0
+        unsafe { ffi::SSL_CTX_remove_session(self.as_ptr(), session.as_ptr()) != 0 }
     }
 
     /// Returns the context's session cache size limit.
@@ -2322,7 +2330,9 @@ impl SslContextRef {
     /// X.509 certificates with an object configured with this method.
     /// You most probably don't need it.
     pub unsafe fn assume_x509(&mut self) {
-        self.replace_ex_data(*X509_FLAG_INDEX, true);
+        unsafe {
+            self.replace_ex_data(*X509_FLAG_INDEX, true);
+        }
     }
 
     /// Returns `true` if context is configured for X.509 certificates.
@@ -2481,7 +2491,7 @@ unsafe impl ForeignType for SslCipher {
 
     #[inline]
     unsafe fn from_ptr(ptr: *mut ffi::SSL_CIPHER) -> SslCipher {
-        SslCipher(SslCipherRef::from_ptr(ptr))
+        SslCipher(unsafe { SslCipherRef::from_ptr(ptr) })
     }
 
     #[inline]
@@ -3541,7 +3551,7 @@ impl SslRef {
     /// with the same `SslContext` as this `Ssl`.
     #[corresponds(SSL_set_session)]
     pub unsafe fn set_session(&mut self, session: &SslSessionRef) -> Result<(), ErrorStack> {
-        cvt(ffi::SSL_set_session(self.as_ptr(), session.as_ptr()))
+        unsafe { cvt(ffi::SSL_set_session(self.as_ptr(), session.as_ptr())) }
     }
 
     /// Determines if the session provided to `set_session` was successfully reused.
@@ -4029,7 +4039,7 @@ impl<S: Read + Write> SslStream<S> {
     ///
     /// The caller must ensure the pointer is valid.
     pub unsafe fn from_raw_parts(ssl: *mut ffi::SSL, stream: S) -> Self {
-        let ssl = Ssl::from_ptr(ssl);
+        let ssl = unsafe { Ssl::from_ptr(ssl) };
         Self::new(ssl, stream).unwrap()
     }
 
@@ -4581,11 +4591,11 @@ pub trait CertificateCompressor: Send + Sync + 'static {
 use crate::ffi::{SSL_CTX_up_ref, SSL_SESSION_get_master_key, SSL_SESSION_up_ref, SSL_is_server};
 
 unsafe fn get_new_idx(f: ffi::CRYPTO_EX_free) -> c_int {
-    ffi::SSL_CTX_get_ex_new_index(0, ptr::null_mut(), ptr::null_mut(), None, f)
+    unsafe { ffi::SSL_CTX_get_ex_new_index(0, ptr::null_mut(), ptr::null_mut(), None, f) }
 }
 
 unsafe fn get_new_ssl_idx(f: ffi::CRYPTO_EX_free) -> c_int {
-    ffi::SSL_get_ex_new_index(0, ptr::null_mut(), ptr::null_mut(), None, f)
+    unsafe { ffi::SSL_get_ex_new_index(0, ptr::null_mut(), ptr::null_mut(), None, f) }
 }
 
 fn path_to_cstring(path: &Path) -> Result<CString, ErrorStack> {

--- a/boring/src/stack.rs
+++ b/boring/src/stack.rs
@@ -253,7 +253,7 @@ impl<T: Stackable> StackRef<T> {
     }
 
     unsafe fn _get(&self, idx: usize) -> *mut T::CType {
-        OPENSSL_sk_value(self.as_stack(), idx).cast()
+        unsafe { OPENSSL_sk_value(self.as_stack(), idx).cast() }
     }
 }
 

--- a/boring/src/string.rs
+++ b/boring/src/string.rs
@@ -83,5 +83,7 @@ impl fmt::Debug for OpensslStringRef {
 }
 
 unsafe fn free(buf: *mut c_char) {
-    crate::ffi::OPENSSL_free(buf.cast());
+    unsafe {
+        crate::ffi::OPENSSL_free(buf.cast());
+    }
 }

--- a/boring/src/util.rs
+++ b/boring/src/util.rs
@@ -46,22 +46,24 @@ pub unsafe extern "C" fn invoke_passwd_cb<F>(
 where
     F: FnOnce(&mut [u8]) -> Result<usize, ErrorStack>,
 {
-    let callback = &mut *cb_state.cast::<CallbackState<F>>();
+    unsafe {
+        let callback = &mut *cb_state.cast::<CallbackState<F>>();
 
-    let result = panic::catch_unwind(AssertUnwindSafe(|| {
-        let pass_slice = slice::from_raw_parts_mut(buf.cast::<u8>(), size as usize);
-        callback.cb.take().unwrap()(pass_slice)
-    }));
+        let result = panic::catch_unwind(AssertUnwindSafe(|| {
+            let pass_slice = slice::from_raw_parts_mut(buf.cast::<u8>(), size as usize);
+            callback.cb.take().unwrap()(pass_slice)
+        }));
 
-    match result {
-        Ok(Ok(len)) => len as c_int,
-        Ok(Err(err)) => {
-            err.put();
-            0
-        }
-        Err(err) => {
-            callback.panic = Some(err);
-            0
+        match result {
+            Ok(Ok(len)) => len as c_int,
+            Ok(Err(err)) => {
+                err.put();
+                0
+            }
+            Err(err) => {
+                callback.panic = Some(err);
+                0
+            }
         }
     }
 }
@@ -72,7 +74,7 @@ pub trait ForeignTypeExt: ForeignType {
         if ptr.is_null() {
             None
         } else {
-            Some(Self::from_ptr(ptr))
+            Some(unsafe { Self::from_ptr(ptr) })
         }
     }
 }
@@ -80,14 +82,14 @@ impl<FT: ForeignType> ForeignTypeExt for FT {}
 
 pub trait ForeignTypeRefExt: ForeignTypeRef {
     unsafe fn from_const_ptr<'a>(ptr: *const Self::CType) -> &'a Self {
-        Self::from_ptr(ptr.cast_mut())
+        unsafe { Self::from_ptr(ptr.cast_mut()) }
     }
 
     unsafe fn from_const_ptr_opt<'a>(ptr: *const Self::CType) -> Option<&'a Self> {
         if ptr.is_null() {
             None
         } else {
-            Some(Self::from_const_ptr(ptr.cast_mut()))
+            Some(unsafe { Self::from_const_ptr(ptr.cast_mut()) })
         }
     }
 }

--- a/boring/src/x509/mod.rs
+++ b/boring/src/x509/mod.rs
@@ -986,8 +986,10 @@ impl X509Extension {
         value: *mut c_void,
     ) -> Result<X509Extension, ErrorStack> {
         ffi::init();
-        cvt_p(ffi::X509V3_EXT_i2d(nid.as_raw(), critical as _, value))
-            .map(|p| X509Extension::from_ptr(p))
+        unsafe {
+            cvt_p(ffi::X509V3_EXT_i2d(nid.as_raw(), critical as _, value))
+                .map(|p| X509Extension::from_ptr(p))
+        }
     }
 }
 
@@ -1613,14 +1615,16 @@ impl GeneralName {
         value: &[u8],
     ) -> Result<GeneralName, ErrorStack> {
         ffi::init();
-        let gn = GeneralName::from_ptr(cvt_p(ffi::GENERAL_NAME_new())?);
-        (*gn.as_ptr()).type_ = type_;
-        let s = cvt_p(ffi::ASN1_STRING_type_new(asn1_type.as_raw()))?;
-        ffi::ASN1_STRING_set(s, value.as_ptr().cast(), value.len().try_into().unwrap());
+        unsafe {
+            let gn = GeneralName::from_ptr(cvt_p(ffi::GENERAL_NAME_new())?);
+            (*gn.as_ptr()).type_ = type_;
+            let s = cvt_p(ffi::ASN1_STRING_type_new(asn1_type.as_raw()))?;
+            ffi::ASN1_STRING_set(s, value.as_ptr().cast(), value.len().try_into().unwrap());
 
-        (*gn.as_ptr()).d.ptr = s.cast();
+            (*gn.as_ptr()).d.ptr = s.cast();
 
-        Ok(gn)
+            Ok(gn)
+        }
     }
 
     pub(crate) fn new_email(email: &[u8]) -> Result<GeneralName, ErrorStack> {
@@ -1784,10 +1788,12 @@ use crate::ffi::X509_OBJECT_get0_X509;
 
 #[allow(bad_style)]
 unsafe fn X509_OBJECT_free(x: *mut ffi::X509_OBJECT) {
-    ffi::X509_OBJECT_free_contents(x);
-    ffi::OPENSSL_free(x.cast());
+    unsafe {
+        ffi::X509_OBJECT_free_contents(x);
+        ffi::OPENSSL_free(x.cast());
+    }
 }
 
 unsafe fn get_new_x509_store_ctx_idx(f: ffi::CRYPTO_EX_free) -> c_int {
-    ffi::X509_STORE_CTX_get_ex_new_index(0, ptr::null_mut(), ptr::null_mut(), None, f)
+    unsafe { ffi::X509_STORE_CTX_get_ex_new_index(0, ptr::null_mut(), ptr::null_mut(), None, f) }
 }

--- a/tokio-boring/src/async_callbacks.rs
+++ b/tokio-boring/src/async_callbacks.rs
@@ -66,7 +66,9 @@ impl SslContextBuilderExt for SslContextBuilder {
     where
         F: Fn(&mut SslRef, &[u8]) -> Option<BoxGetSessionFuture> + Send + Sync + 'static,
     {
-        self.set_async_get_session_callback(callback);
+        unsafe {
+            self.set_async_get_session_callback(callback);
+        }
     }
 }
 

--- a/tokio-boring/src/lib.rs
+++ b/tokio-boring/src/lib.rs
@@ -186,10 +186,12 @@ where
     ///
     /// The caller must ensure the pointer is valid.
     pub unsafe fn from_raw_parts(ssl: *mut ffi::SSL, stream: S) -> Self {
-        Self(ssl::SslStream::from_raw_parts(
-            ssl,
-            AsyncStreamBridge::new(stream),
-        ))
+        unsafe {
+            Self(ssl::SslStream::from_raw_parts(
+                ssl,
+                AsyncStreamBridge::new(stream),
+            ))
+        }
     }
 }
 


### PR DESCRIPTION
This is warn-by-default in the latest Rust edition