### PR TITLE
Backport new v5 functions to v4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "4.21.2"
+version = "4.22.0"
 repository = "https://github.com/cloudflare/boring"
 edition = "2021"
 
@@ -19,9 +19,9 @@ tag-prefix = ""
 publish = false
 
 [workspace.dependencies]
-boring-sys = { version = "4.21.2", path = "./boring-sys" }
-boring = { version = "4.21.2", path = "./boring" }
-tokio-boring = { version = "4.21.2", path = "./tokio-boring" }
+boring-sys = { version = "4.22.0", path = "./boring-sys" }
+boring = { version = "4.22.0", path = "./boring" }
+tokio-boring = { version = "4.22.0", path = "./tokio-boring" }
 
 bindgen = { version = "0.72.0", default-features = false, features = ["runtime"] }
 bitflags = "2.9"

--- a/boring-sys/build/main.rs
+++ b/boring-sys/build/main.rs
@@ -287,12 +287,10 @@ fn get_boringssl_cmake_config(config: &Config) -> cmake::Config {
             boringssl_cmake.cflag(&cflag);
         }
 
-        "windows" => {
-            if config.host.contains("windows") {
-                // BoringSSL's CMakeLists.txt isn't set up for cross-compiling using Visual Studio.
-                // Disable assembly support so that it at least builds.
-                boringssl_cmake.define("OPENSSL_NO_ASM", "YES");
-            }
+        "windows" if config.host.contains("windows") => {
+            // BoringSSL's CMakeLists.txt isn't set up for cross-compiling using Visual Studio.
+            // Disable assembly support so that it at least builds.
+            boringssl_cmake.define("OPENSSL_NO_ASM", "YES");
         }
 
         "linux" => match &*config.target_arch {

--- a/boring/src/ssl/mod.rs
+++ b/boring/src/ssl/mod.rs
@@ -2537,6 +2537,13 @@ unsafe impl ForeignTypeRef for SslCipherRef {
 }
 
 impl SslCipherRef {
+    /// Returns the IANA number of the cipher.
+    #[corresponds(SSL_CIPHER_get_protocol_id)]
+    #[must_use]
+    pub fn protocol_id(&self) -> u16 {
+        unsafe { ffi::SSL_CIPHER_get_protocol_id(self.as_ptr()) }
+    }
+
     /// Returns the name of the cipher.
     #[corresponds(SSL_CIPHER_get_name)]
     #[must_use]

--- a/boring/src/ssl/mod.rs
+++ b/boring/src/ssl/mod.rs
@@ -1330,16 +1330,27 @@ impl SslContextBuilder {
     /// The file should contain a sequence of PEM-formatted CA certificates.
     #[corresponds(SSL_CTX_load_verify_locations)]
     pub fn set_ca_file<P: AsRef<Path>>(&mut self, file: P) -> Result<(), ErrorStack> {
+        self.load_verify_locations(Some(file.as_ref()), None)
+    }
+
+    /// Loads trusted root certificates from a file and/or a directory.
+    #[corresponds(SSL_CTX_load_verify_locations)]
+    pub fn load_verify_locations(
+        &mut self,
+        ca_file: Option<&Path>,
+        ca_path: Option<&Path>,
+    ) -> Result<(), ErrorStack> {
         #[cfg(feature = "rpk")]
         assert!(!self.is_rpk, "This API is not supported for RPK");
 
-        let file = CString::new(file.as_ref().as_os_str().as_encoded_bytes())
-            .map_err(ErrorStack::internal_error)?;
+        let ca_file = ca_file.map(path_to_cstring).transpose()?;
+        let ca_path = ca_path.map(path_to_cstring).transpose()?;
+
         unsafe {
             cvt(ffi::SSL_CTX_load_verify_locations(
                 self.as_ptr(),
-                file.as_ptr() as *const _,
-                ptr::null(),
+                ca_file.as_ref().map_or(ptr::null(), |s| s.as_ptr()),
+                ca_path.as_ref().map_or(ptr::null(), |s| s.as_ptr()),
             ))
             .map(|_| ())
         }
@@ -1405,8 +1416,7 @@ impl SslContextBuilder {
         #[cfg(feature = "rpk")]
         assert!(!self.is_rpk, "This API is not supported for RPK");
 
-        let file = CString::new(file.as_ref().as_os_str().as_encoded_bytes())
-            .map_err(ErrorStack::internal_error)?;
+        let file = path_to_cstring(file.as_ref())?;
         unsafe {
             cvt(ffi::SSL_CTX_use_certificate_file(
                 self.as_ptr(),
@@ -1427,8 +1437,7 @@ impl SslContextBuilder {
         &mut self,
         file: P,
     ) -> Result<(), ErrorStack> {
-        let file = CString::new(file.as_ref().as_os_str().as_encoded_bytes())
-            .map_err(ErrorStack::internal_error)?;
+        let file = path_to_cstring(file.as_ref())?;
         unsafe {
             cvt(ffi::SSL_CTX_use_certificate_chain_file(
                 self.as_ptr(),
@@ -1468,8 +1477,7 @@ impl SslContextBuilder {
         file: P,
         file_type: SslFiletype,
     ) -> Result<(), ErrorStack> {
-        let file = CString::new(file.as_ref().as_os_str().as_encoded_bytes())
-            .map_err(ErrorStack::internal_error)?;
+        let file = path_to_cstring(file.as_ref())?;
         unsafe {
             cvt(ffi::SSL_CTX_use_PrivateKey_file(
                 self.as_ptr(),
@@ -4699,4 +4707,8 @@ unsafe fn get_new_ssl_idx(f: ffi::CRYPTO_EX_free) -> c_int {
     });
 
     ffi::SSL_get_ex_new_index(0, ptr::null_mut(), ptr::null_mut(), None, f)
+}
+
+fn path_to_cstring(path: &Path) -> Result<CString, ErrorStack> {
+    CString::new(path.as_os_str().as_encoded_bytes()).map_err(ErrorStack::internal_error)
 }

--- a/boring/src/ssl/mod.rs
+++ b/boring/src/ssl/mod.rs
@@ -3018,6 +3018,21 @@ impl SslRef {
         Some(SslCurve(curve_id.into()))
     }
 
+    /// Returns the curve name used for this `SslRef`.
+    #[corresponds(SSL_get_curve_name)]
+    #[must_use]
+    pub fn curve_name(&self) -> Option<&'static str> {
+        unsafe {
+            let curve_id = ffi::SSL_get_curve_id(self.as_ptr());
+            let ptr = ffi::SSL_get_curve_name(curve_id);
+            if ptr.is_null() {
+                return None;
+            }
+
+            CStr::from_ptr(ptr).to_str().ok()
+        }
+    }
+
     /// Returns an `ErrorCode` value for the most recent operation on this `SslRef`.
     #[corresponds(SSL_get_error)]
     #[must_use]

--- a/boring/src/ssl/test/mod.rs
+++ b/boring/src/ssl/test/mod.rs
@@ -986,6 +986,8 @@ fn get_curve() {
     let client_stream = client.connect();
     let curve = client_stream.ssl().curve().expect("curve");
     assert!(curve.name().is_some());
+    let curve_name = client_stream.ssl().curve_name();
+    assert!(curve_name.is_some());
 }
 
 #[test]


### PR DESCRIPTION
This cherry-picks simple functions added in v5 to v4. This helps with migration to v5, because users can start making API changes (such as switch to curve names) even if they're blocked from upgrading for other reasons (such as their deps not supporting v5 yet).

