### PR TITLE
Let crates detect boring-sys version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "5.1.0"
+version = "5.2.0"
 rust-version = "1.85"
 repository = "https://github.com/cloudflare/boring"
 edition = "2021"
@@ -20,9 +20,9 @@ tag-prefix = ""
 publish = false
 
 [workspace.dependencies]
-boring-sys = { version = "5.1.0", path = "./boring-sys", default-features = false }
-boring = { version = "5.1.0", path = "./boring", default-features = false }
-tokio-boring = { version = "5.1.0", path = "./tokio-boring", default-features = false }
+boring-sys = { version = "5.2.0", path = "./boring-sys", default-features = false }
+boring = { version = "5.2.0", path = "./boring", default-features = false }
+tokio-boring = { version = "5.2.0", path = "./tokio-boring", default-features = false }
 
 bindgen = { version = "0.72.0", default-features = false, features = ["runtime"] }
 bitflags = "2.9"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ and [Raw Public Key](https://docs.rs/boring/latest/boring/ssl/struct.SslRef.html
 
 # Upgrading from `boring` v4
 
- * First update to boring 4.21 and ensure it builds without any deprecation warnings.
+ * First update to boring 4.22 and ensure it builds without any deprecation warnings.
  * `pq-experimental` Cargo feature is no longer needed. Post-quantum crypto is enabled by default.
  * `fips-precompiled` Cargo feature has been merged into `fips`. Set `BORING_BSSL_FIPS_PATH` env var to use a precompiled library.
  * `fips-compat` Cargo feature has been renamed to `legacy-compat-deprecated` (4cb7e260a85b7)
@@ -29,6 +29,8 @@ and [Raw Public Key](https://docs.rs/boring/latest/boring/ssl/struct.SslRef.html
  * `X509Store` is now cheaply cloneable, but immutable. `SslContextBuilder.cert_store_mut()` can't be used after `.set_cert_store()`. If you need `.cert_store_mut()`, either don't overwrite the default store, or use `.set_cert_store_builder()`.
  * `X509StoreBuilder::add_cert` takes a reference.
  * `hyper` 0.x support has been removed. Use `hyper` 1.x.
+
+To support both v4 and v5, add `boring = ">=4.22,<6"` to `Cargo.toml`. If you need to auto-detect the version selected, add `boring-sys = ">=4.22,<6"` as a direct dependency, and in your `build.rs` check if `DEP_BORINGSSL_VERSION_MAJOR` env var is set to `5`. Versions older than 5.2.0 don't set it.
 
 ## Contribution
 

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,3 +1,7 @@
+5.2.0
+- 2026-05-21 Export `DEP_BORINGSSL_VERSION_MAJOR` var
+- 2026-04-27 Expose DTLS version constants in SslVersion
+
 5.1.0
 - 2026-04-13 Add EVP_AEAD-based detached AEAD module
 - 2026-04-13 Add generic PKey private key generation API

--- a/boring-sys/build/config.rs
+++ b/boring-sys/build/config.rs
@@ -71,6 +71,12 @@ impl Config {
             .as_ref()
             .is_some_and(|path| path.join("src").exists());
 
+        // DEP_BORINGSSL_VERSION_MAJOR
+        println!(
+            "cargo:version_major={}",
+            env::var("CARGO_PKG_VERSION_MAJOR").unwrap_or_default()
+        );
+
         let config = Self {
             manifest_dir,
             out_dir,


### PR DESCRIPTION
Helps support both v4 and v5 where APIs differ