### PR TITLE
Fix dangling pointer in `X509StoreContextRef::set_verify_param`

### DIFF
--- a/boring/src/x509/mod.rs
+++ b/boring/src/x509/mod.rs
@@ -247,7 +247,7 @@ impl X509StoreContextRef {
     /// Sets the X509 verification configuration.
     #[corresponds(X509_STORE_CTX_set0_param)]
     pub fn set_verify_param(&mut self, param: X509VerifyParam) {
-        unsafe { ffi::X509_STORE_CTX_set0_param(self.as_ptr(), param.as_ptr()) }
+        unsafe { ffi::X509_STORE_CTX_set0_param(self.as_ptr(), param.into_ptr()) }
     }
 
     /// Verifies the stored certificate.


### PR DESCRIPTION
`param` is dropped at the end of the function after its pointer was taken via `.as_ptr()`. Instead, `param` should be converted into a pointer via `.into_ptr()` without being dropped.