### PR TITLE
fix(boring-sys): localize allocator hooks on Android

### DIFF
--- a/boring-sys/build/main.rs
+++ b/boring-sys/build/main.rs
@@ -519,6 +519,11 @@ fn ensure_patches_applied(config: &Config) -> io::Result<()> {
         apply_patch(config, "underscore-wildcards.patch")?;
     }
 
+    if config.target_os == "android" {
+        println!("cargo:warning=disabling weak allocator hooks on Android");
+        apply_patch(config, "android-local-memory-hooks.patch")?;
+    }
+
     Ok(())
 }
 

--- a/boring-sys/patches/android-local-memory-hooks.patch
+++ b/boring-sys/patches/android-local-memory-hooks.patch
@@ -1,0 +1,13 @@
+diff --git a/src/crypto/mem.c b/src/crypto/mem.c
+index e4398d1a7..71e533524 100644
+--- a/src/crypto/mem.c
++++ b/src/crypto/mem.c
+@@ -94,7 +94,7 @@ static void __asan_unpoison_memory_region(const void *addr, size_t size) {}
+ // Windows doesn't really support weak symbols as of May 2019, and Clang on
+ // Windows will emit strong symbols instead. See
+ // https://bugs.llvm.org/show_bug.cgi?id=37598
+-#if defined(__ELF__) && defined(__GNUC__)
++#if defined(__ELF__) && defined(__GNUC__) && !defined(__ANDROID__)
+ #define WEAK_SYMBOL_FUNC(rettype, name, args) \
+   rettype name args __attribute__((weak));
+ #else


### PR DESCRIPTION
## Summary

Avoid weak BoringSSL allocator hooks on Android.

BoringSSL exposes `OPENSSL_memory_alloc`, `OPENSSL_memory_free`, and
`OPENSSL_memory_get_size` as weak ELF symbols. When `boring-sys` is linked
into an Android shared library alongside other native dependencies, these
symbols can be resolved to incompatible process symbols and cause a crash
during BoringSSL initialization.

This change applies an Android-only patch that uses BoringSSL's existing
local null-function-pointer fallback instead. Other platforms retain the
current weak-symbol behavior.

## Verification

- Cross-compiled `boring-sys` and a downstream UniFFI library for
  `aarch64-linux-android`.
- Verified the resulting `libcrypto.a` reports all three allocator hooks as
  `LOCAL OBJECT`.
- Tested endpoint construction in a React Native/Hermes app on a physical
  arm64 Android device.
- Confirmed BoringSSL initializes successfully without the previous
  `SIGSEGV`.
- `cargo fmt --all -- --check` passes.