### PR TITLE
boring-sys: add tvOS target support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,8 @@ jobs:
         - aarch64-ios
         - aarch64-ios-sim
         - x86_64-ios
+        - aarch64-tvos
+        - aarch64-tvos-sim
         - i686-linux
         - arm-linux
         - aarch64-linux
@@ -159,6 +161,18 @@ jobs:
           check_only: true
           custom_env:
             IPHONEOS_DEPLOYMENT_TARGET: 17.5
+        - thing: aarch64-tvos
+          target: aarch64-apple-tvos
+          os: macos-latest
+          check_only: true
+          custom_env:
+            TVOS_DEPLOYMENT_TARGET: 17.5
+        - thing: aarch64-tvos-sim
+          target: aarch64-apple-tvos-sim
+          os: macos-latest
+          check_only: true
+          custom_env:
+            TVOS_DEPLOYMENT_TARGET: 17.5
         - thing: i686-linux
           target: i686-unknown-linux-gnu
           rust: stable

--- a/boring-sys/build/main.rs
+++ b/boring-sys/build/main.rs
@@ -17,7 +17,7 @@ fn should_use_cmake_cross_compilation(config: &Config) -> bool {
         return false;
     }
     match config.target_os.as_str() {
-        "macos" | "ios" => {
+        "macos" | "ios" | "tvos" => {
             // Cross-compiling for Apple platforms on macOS is supported using the normal Xcode
             // tools, along with the settings from `cmake_params_apple`.
             !config.host.ends_with("-darwin")
@@ -66,6 +66,31 @@ const CMAKE_PARAMS_APPLE: &[(&str, &[(&str, &str)])] = &[
         &[
             ("CMAKE_OSX_ARCHITECTURES", "x86_64"),
             ("CMAKE_OSX_SYSROOT", "iphonesimulator"),
+            ("CMAKE_MACOSX_BUNDLE", "OFF"),
+        ],
+    ),
+    // tvOS
+    (
+        "aarch64-apple-tvos",
+        &[
+            ("CMAKE_OSX_ARCHITECTURES", "arm64"),
+            ("CMAKE_OSX_SYSROOT", "appletvos"),
+            ("CMAKE_MACOSX_BUNDLE", "OFF"),
+        ],
+    ),
+    (
+        "aarch64-apple-tvos-sim",
+        &[
+            ("CMAKE_OSX_ARCHITECTURES", "arm64"),
+            ("CMAKE_OSX_SYSROOT", "appletvsimulator"),
+            ("CMAKE_MACOSX_BUNDLE", "OFF"),
+        ],
+    ),
+    (
+        "x86_64-apple-tvos",
+        &[
+            ("CMAKE_OSX_ARCHITECTURES", "x86_64"),
+            ("CMAKE_OSX_SYSROOT", "appletvsimulator"),
             ("CMAKE_MACOSX_BUNDLE", "OFF"),
         ],
     ),
@@ -308,6 +333,15 @@ fn get_boringssl_cmake_config(config: &Config) -> cmake::Config {
             boringssl_cmake.cflag(&cflag);
         }
 
+        "tvos" => {
+            // Unlike the `ios` arm above, no bitcode flag: bitcode was deprecated in
+            // Xcode 14 and the tvOS targets postdate it, so the SDK never wants it.
+            for (name, value) in cmake_params_apple(config) {
+                eprintln!("tvos arch={} add {}={}", config.target_arch, name, value);
+                boringssl_cmake.define(name, value);
+            }
+        }
+
         "windows" if config.host.contains("windows") => {
             // BoringSSL's CMakeLists.txt isn't set up for cross-compiling using Visual Studio.
             // Disable assembly support so that it at least builds.
@@ -391,7 +425,7 @@ fn get_extra_clang_args_for_bindgen(config: &Config) -> Vec<String> {
 
     // Add platform-specific parameters.
     match &*config.target_os {
-        "ios" | "macos" => {
+        "ios" | "macos" | "tvos" => {
             // When cross-compiling for Apple targets, tell bindgen to use SDK sysroot,
             // and *don't* use system headers of the host macOS.
             let sdk = get_apple_sdk_name(config);
@@ -589,7 +623,7 @@ fn get_cpp_runtime_lib(config: &Config) -> Option<String> {
     }
 
     match &*config.target_os {
-        "macos" | "ios" | "freebsd" | "openbsd" | "android" => Some("c++".into()),
+        "macos" | "ios" | "tvos" | "freebsd" | "openbsd" | "android" => Some("c++".into()),
         _ if config.unix || config.target_env == "gnu" => Some("stdc++".into()),
         // TODO(rmehra): figure out how to do this for windows
         _ => None,


### PR DESCRIPTION
## What

Adds `aarch64-apple-tvos` / `aarch64-apple-tvos-sim` support to `boring-sys`, and covers both in CI.

## Why it doesn't build today

Five places in `boring-sys/build/main.rs` handle `macos`/`ios` but fall through on `tvos`:

1. **`should_use_cmake_cross_compilation`** — `tvos` isn't in the Apple arm, so it returns `true` even on a darwin host. That forces `CMAKE_CROSSCOMPILING=true` + `CMAKE_{C,CXX,ASM}_COMPILER_TARGET`, which conflicts with the Xcode-SDK path the other Apple targets take.
2. **`CMAKE_PARAMS_APPLE`** — no tvOS rows, so no `CMAKE_OSX_SYSROOT` / `CMAKE_OSX_ARCHITECTURES`, and `CMAKE_MACOSX_BUNDLE` stays at its default `ON`. BoringSSL's `bssl` host tool then fails at CMake install time.
3. **`get_boringssl_cmake_config`** — no `"tvos"` arm, so none of the above gets applied even once the table has rows.
4. **`get_extra_clang_args_for_bindgen`** — `tvos` misses the `-isysroot` the `ios`/`macos` arm supplies, so bindgen can't find `TargetConditionals.h`.
5. **`get_cpp_runtime_lib`** — falls through to the `_ => Some("stdc++")` default. Apple platforms have no `libstdc++`; this is a link failure, and it's the one that only shows up if you actually run the linker.

Each of the five is a one-line-ish addition of `"tvos"` alongside the existing Apple arms.

The one deliberate asymmetry with the `ios` arm: no bitcode flag. Bitcode was deprecated in Xcode 14 and the tvOS Rust targets postdate that, so the SDK never wants it.

## CI

Two rows added to the existing `test` job matrix, next to the iOS ones, same `check_only: true` shape:

```yaml
- thing: aarch64-tvos
  target: aarch64-apple-tvos
  os: macos-latest
  check_only: true
  custom_env:
    TVOS_DEPLOYMENT_TARGET: 17.5
- thing: aarch64-tvos-sim
  target: aarch64-apple-tvos-sim
  os: macos-latest
  check_only: true
  custom_env:
    TVOS_DEPLOYMENT_TARGET: 17.5
```

That job's `check_only` path runs `cargo build -vv --target ... --tests` rather than `cargo check` — per its own comment, so the linker verifies the cross-compile. That matters here: item (5) above is a *link* error, so `cargo check` would have passed while the target stayed broken.

`x86_64-apple-tvos` gets a `CMAKE_PARAMS_APPLE` row too, but is **not** in CI. It's a Tier 3 target with no prebuilt std — `rustup target add x86_64-apple-tvos` fails outright — so it's only reachable via `-Z build-std` on nightly. The row is there so that path works; gating CI on it would need a nightly + `build-std` job.

## Verification

Green on both new matrix rows: <https://github.com/gengjiawen/boring/actions/runs/30448778000>

```
success  Test (aarch64-tvos)
success  Test (aarch64-tvos-sim)
success  Test (aarch64-ios)
success  Test (aarch64-ios-sim)
success  Test (x86_64-ios)
```

`-vv` makes the build-script stderr visible, so the new code path is directly observable in the `Test (aarch64-tvos)` log rather than merely inferred:

```
[boring-sys 5.2.0] tvos arch=aarch64 add CMAKE_OSX_ARCHITECTURES=arm64
[boring-sys 5.2.0] tvos arch=aarch64 add CMAKE_OSX_SYSROOT=appletvos
[boring-sys 5.2.0] tvos arch=aarch64 add CMAKE_MACOSX_BUNDLE=OFF
```

and the resulting cmake invocation picks up the real tvOS SDK and version-min:

```
SDKROOT=".../AppleTVOS.platform/Developer/SDKs/AppleTVOS26.5.sdk" "cmake" ...
  "-DCMAKE_OSX_SYSROOT=appletvos"
  "-DCMAKE_C_FLAGS= -fPIC --target=arm64-apple-tvos -mappletvos-version-min=17.5 -isysroot .../AppleTVOS26.5.sdk -w"
```

(`-DCMAKE_SYSTEM_NAME=tvOS` also appears in that line; that one comes from the `cmake` crate's own target detection, not from this change. `CMAKE_CROSSCOMPILING` is correctly absent, which is item (1) working.)

## Motivation

tvOS 17 made `NEPacketTunnelProvider` available, so Rust network stacks that were iOS-only can now target Apple TV. `boring-sys` is the first thing that breaks when you try.
