### PR TITLE
Exclude non-BoringSSL items from bindings

### DIFF
--- a/boring-sys/build/main.rs
+++ b/boring-sys/build/main.rs
@@ -791,7 +791,10 @@ fn generate_bindings(config: &Config) -> Result<PathBuf, Box<dyn std::error::Err
         .layout_tests(config.env.debug.is_some())
         .merge_extern_blocks(true)
         .prepend_enum_name(true)
+        .allowlist_item("[A-Z].*|.*_.*|tm.*|time.*") // Exclude unprefixed stdlib and POSIX functions
+        .blocklist_item("rusage.*|RLIMIT.*|USE_CLANG.*|__?v?snprintf.*|.*DEPRECATED.*|sig[a-z0-9]*_t|__sig.*|_?sigaction.*|__darwin_(arm_|[um]context).*|[um]context_t|__arm_.*|__AVAIL.*|MAC_OS_(X_)?VER.*")
         .blocklist_type("max_align_t") // Not supported by bindgen on all targets, not used by BoringSSL
+        .opaque_type("__?opaque_.*")
         .clang_args(get_extra_clang_args_for_bindgen(config))
         .clang_arg("-I")
         .clang_arg(include_path.display().to_string());

--- a/boring-sys/src/lib.rs
+++ b/boring-sys/src/lib.rs
@@ -71,6 +71,7 @@ pub fn init() {
 
 // CBS_init is inline in BoringSSL, so bindgen can't generate bindings for it.
 #[inline]
+#[must_use]
 pub fn cbs_init(data: &[u8]) -> CBS {
     CBS {
         data: data.as_ptr(),

--- a/boring/src/asn1.rs
+++ b/boring/src/asn1.rs
@@ -678,8 +678,8 @@ mod tests {
         assert!(a != c_ref);
         assert!(b_ref == a);
         assert!(c_ref != a);
-        assert!(a_ref == b_ref);
-        assert!(a_ref != c_ref);
+        assert_eq!(a_ref, b_ref);
+        assert_ne!(a_ref, c_ref);
     }
 
     #[test]

--- a/boring/src/ec.rs
+++ b/boring/src/ec.rs
@@ -559,7 +559,7 @@ impl<T> ToOwned for EcKeyRef<T> {
     fn to_owned(&self) -> EcKey<T> {
         unsafe {
             let r = ffi::EC_KEY_up_ref(self.as_ptr());
-            assert!(r == 1);
+            assert_eq!(r, 1);
             EcKey::from_ptr(self.as_ptr())
         }
     }
@@ -878,7 +878,7 @@ mod test {
             EcKey::from_private_components(&group, key.private_key(), key.public_key()).unwrap();
         dup_key.check_key().unwrap();
 
-        assert!(key.private_key() == dup_key.private_key());
+        assert_eq!(key.private_key(), dup_key.private_key());
     }
 
     #[test]

--- a/boring/src/error.rs
+++ b/boring/src/error.rs
@@ -331,7 +331,7 @@ impl Error {
     }
 
     fn is_internal(&self) -> bool {
-        std::ptr::eq(self.file, BORING_INTERNAL.as_ptr())
+        ptr::eq(self.file, BORING_INTERNAL.as_ptr())
     }
 }
 

--- a/boring/src/memcmp.rs
+++ b/boring/src/memcmp.rs
@@ -62,7 +62,7 @@ use crate::ffi;
 /// ```
 #[must_use]
 pub fn eq(a: &[u8], b: &[u8]) -> bool {
-    assert!(a.len() == b.len());
+    assert_eq!(a.len(), b.len());
     let ret = unsafe { ffi::CRYPTO_memcmp(a.as_ptr().cast(), b.as_ptr().cast(), a.len()) };
     ret == 0
 }

--- a/boring/src/pkcs12.rs
+++ b/boring/src/pkcs12.rs
@@ -118,6 +118,7 @@ pub struct ParsedPkcs12_2 {
 }
 
 impl ParsedPkcs12_2 {
+    #[must_use]
     pub fn chain(&self) -> Option<&StackRef<X509>> {
         self.ca.as_deref()
     }

--- a/boring/src/pkey.rs
+++ b/boring/src/pkey.rs
@@ -237,7 +237,7 @@ where
             let mut size = 0;
             _ = cvt_0i(ffi::EVP_PKEY_get_raw_public_key(
                 self.as_ptr(),
-                std::ptr::null_mut(),
+                ptr::null_mut(),
                 &mut size,
             ))?;
             Ok(size)
@@ -305,7 +305,7 @@ where
             let mut size = 0;
             _ = cvt_0i(ffi::EVP_PKEY_get_raw_private_key(
                 self.as_ptr(),
-                std::ptr::null_mut(),
+                ptr::null_mut(),
                 &mut size,
             ))?;
             Ok(size)

--- a/boring/src/ssl/callbacks.rs
+++ b/boring/src/ssl/callbacks.rs
@@ -41,7 +41,7 @@ where
 
     // SAFETY: The callback won't outlive the context it's associated with
     // because there is no `X509StoreContextRef::ssl_mut(&mut self)` method.
-    let verify = unsafe { &*std::ptr::from_ref::<F>(verify) };
+    let verify = unsafe { &*ptr::from_ref::<F>(verify) };
 
     c_int::from(verify(preverify_ok != 0, ctx))
 }
@@ -90,7 +90,7 @@ where
     // SAFETY: The callback won't outlive the context it's associated with
     // because there is no way to get a mutable reference to the `SslContext`,
     // so the callback can't replace itself.
-    let verify = unsafe { &*std::ptr::from_ref::<F>(verify) };
+    let verify = unsafe { &*ptr::from_ref::<F>(verify) };
 
     c_int::from(verify(ctx))
 }
@@ -442,7 +442,7 @@ where
     // SAFETY: We can make `callback` outlive `ssl` because it is a callback
     // stored in the session context set in `Ssl::new` so it is always
     // guaranteed to outlive the lifetime of this function's scope.
-    let callback = unsafe { &*std::ptr::from_ref::<F>(callback) };
+    let callback = unsafe { &*ptr::from_ref::<F>(callback) };
 
     callback(ssl, session);
 
@@ -495,7 +495,7 @@ where
     // SAFETY: We can make `callback` outlive `ssl` because it is a callback
     // stored in the session context set in `Ssl::new` so it is always
     // guaranteed to outlive the lifetime of this function's scope.
-    let callback = unsafe { &*std::ptr::from_ref::<F>(callback) };
+    let callback = unsafe { &*ptr::from_ref::<F>(callback) };
 
     match callback(ssl, data) {
         Ok(Some(session)) => {
@@ -666,7 +666,7 @@ where
         .ex_data(SslContext::cached_ex_index::<C>())
         .expect("BUG: certificate compression missed");
 
-    let input_slice = unsafe { std::slice::from_raw_parts(input, input_len) };
+    let input_slice = unsafe { slice::from_raw_parts(input, input_len) };
     let mut writer = CryptoByteBuilder::from_ptr(out);
     if compressor.compress(input_slice, &mut writer).is_err() {
         return 0;
@@ -701,7 +701,7 @@ where
         return 0;
     };
 
-    let input_slice = unsafe { std::slice::from_raw_parts(input, input_len) };
+    let input_slice = unsafe { slice::from_raw_parts(input, input_len) };
 
     if compressor
         .decompress(input_slice, decompression_buffer.as_writer())
@@ -751,11 +751,11 @@ struct CryptoBufferBuilder<'a> {
 
 impl<'a> CryptoBufferBuilder<'a> {
     fn with_capacity(capacity: usize) -> Result<CryptoBufferBuilder<'a>, ErrorStack> {
-        let mut data: *mut u8 = std::ptr::null_mut();
+        let mut data: *mut u8 = ptr::null_mut();
         let buffer = unsafe { crate::cvt_p(ffi::CRYPTO_BUFFER_alloc(&mut data, capacity))? };
         Ok(CryptoBufferBuilder {
             buffer,
-            cursor: std::io::Cursor::new(unsafe { std::slice::from_raw_parts_mut(data, capacity) }),
+            cursor: std::io::Cursor::new(unsafe { slice::from_raw_parts_mut(data, capacity) }),
         })
     }
 

--- a/boring/src/ssl/credential.rs
+++ b/boring/src/ssl/credential.rs
@@ -97,7 +97,7 @@ impl SslCredentialRef {
         if data.is_null() {
             None
         } else {
-            Some(&mut *(data as *mut T))
+            Some(&mut *data.cast::<T>())
         }
     }
 
@@ -114,7 +114,7 @@ impl SslCredentialRef {
         }
 
         unsafe {
-            let data = Box::into_raw(Box::new(data)) as *mut c_void;
+            let data = Box::into_raw(Box::new(data)).cast::<c_void>();
             ffi::SSL_CREDENTIAL_set_ex_data(self.as_ptr(), index.as_raw(), data);
         }
 

--- a/boring/src/ssl/mod.rs
+++ b/boring/src/ssl/mod.rs
@@ -2126,7 +2126,7 @@ impl SslContextBuilder {
         unsafe {
             cvt_0i(ffi::SSL_CTX_set1_accepted_peer_cert_types(
                 self.as_ptr(),
-                types.as_ptr() as *const u8,
+                types.as_ptr().cast::<u8>(),
                 types.len(),
             ))
             .map(|_| ())
@@ -2434,7 +2434,7 @@ impl SslContextRef {
             }
 
             Some(slice::from_raw_parts(
-                types as *const CertificateType,
+                types.cast::<CertificateType>(),
                 types_len,
             ))
         }
@@ -3966,7 +3966,7 @@ impl SslRef {
                 return None;
             }
 
-            Some(PKeyRef::from_ptr(pubkey as *mut _))
+            Some(PKeyRef::from_ptr(pubkey.cast_mut()))
         }
     }
 
@@ -3989,7 +3989,7 @@ impl SslRef {
         unsafe {
             cvt_0i(ffi::SSL_set1_accepted_peer_cert_types(
                 self.as_ptr(),
-                types.as_ptr() as *const u8,
+                types.as_ptr().cast::<u8>(),
                 types.len(),
             ))
             .map(|_| ())
@@ -4018,7 +4018,7 @@ impl SslRef {
             }
 
             Some(slice::from_raw_parts(
-                types as *const CertificateType,
+                types.cast::<CertificateType>(),
                 types_len,
             ))
         }

--- a/boring/src/ssl/mod.rs
+++ b/boring/src/ssl/mod.rs
@@ -3024,6 +3024,7 @@ impl SslRef {
     }
 
     /// Returns whether the TLS 1.3 HelloRetryRequest was used
+    #[must_use]
     pub fn used_hello_retry_request(&self) -> bool {
         unsafe { ffi::SSL_used_hello_retry_request(self.as_ptr()) == 1 }
     }
@@ -3956,6 +3957,7 @@ impl SslRef {
     /// Returns the public key sent by the other peer, `None` if there is no ongoing handshake.
     #[corresponds(SSL_get0_peer_pubkey)]
     #[cfg(feature = "rpk")]
+    #[must_use]
     pub fn peer_pubkey(&self) -> Option<&PKeyRef<Public>> {
         unsafe {
             let pubkey = ffi::SSL_get0_peer_pubkey(self.as_ptr());

--- a/boring/src/ssl/test/cert_verify.rs
+++ b/boring/src/ssl/test/cert_verify.rs
@@ -118,7 +118,7 @@ fn callback_receives_correct_chain() {
         assert!(x509.current_cert().is_some());
         assert!(x509.verify_result().is_ok());
         let chain = x509.chain().unwrap();
-        assert!(chain.len() == 2);
+        assert_eq!(chain.len(), 2);
         let leaf_cert = chain.get(0).unwrap();
         let leaf_digest = leaf_cert.digest(MessageDigest::sha1()).unwrap();
         assert_eq!(hex::encode(leaf_digest), leaf_sha1);

--- a/boring/src/ssl/test/mod.rs
+++ b/boring/src/ssl/test/mod.rs
@@ -622,7 +622,7 @@ fn flush_panic() {
 fn refcount_ssl_context() {
     let mut ssl = {
         let ctx = SslContext::builder(SslMethod::tls()).unwrap();
-        ssl::Ssl::new(&ctx.build()).unwrap()
+        Ssl::new(&ctx.build()).unwrap()
     };
 
     {
@@ -1011,7 +1011,7 @@ fn psk_ciphers() {
     let mut server = Server::builder();
     server.ctx().set_cipher_list(CIPHER).unwrap();
     server.ctx().set_psk_server_callback(|_, identity, psk| {
-        assert!(identity.unwrap_or(&[]) == CLIENT_IDENT);
+        assert_eq!(identity.unwrap_or(&[]), CLIENT_IDENT);
         psk[..PSK.len()].copy_from_slice(PSK);
         SERVER_CALLED.store(true, Ordering::SeqCst);
         Ok(PSK.len())
@@ -1021,7 +1021,7 @@ fn psk_ciphers() {
 
     let mut client = server.client();
     // This test relies on TLS 1.2 suites
-    client.ctx().set_options(super::SslOptions::NO_TLSV1_3);
+    client.ctx().set_options(SslOptions::NO_TLSV1_3);
     client.ctx().set_cipher_list(CIPHER).unwrap();
     client
         .ctx()
@@ -1338,7 +1338,7 @@ fn peer_signature_algorithm_mtls_server_sees_client() {
     // Observe from a server-side HANDSHAKE_DONE info callback so the capture
     // happens synchronously during the server's accept, before the client's
     // connect() returns.
-    let captured = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let captured = std::sync::Arc::new(AtomicBool::new(false));
 
     let mut server_builder = Server::builder();
     {
@@ -1356,7 +1356,7 @@ fn peer_signature_algorithm_mtls_server_sees_client() {
                 if mode == SslInfoCallbackMode::HANDSHAKE_DONE {
                     if let Some(sa) = ssl.peer_signature_algorithm() {
                         assert!(sa.name().is_some(), "client sig scheme should have a name");
-                        captured_cb.store(true, std::sync::atomic::Ordering::SeqCst);
+                        captured_cb.store(true, Ordering::SeqCst);
                     }
                 }
             });
@@ -1375,7 +1375,7 @@ fn peer_signature_algorithm_mtls_server_sees_client() {
     let _ = client_builder.connect();
 
     assert!(
-        captured.load(std::sync::atomic::Ordering::SeqCst),
+        captured.load(Ordering::SeqCst),
         "server should observe client signature scheme during mTLS",
     );
 }
@@ -1384,7 +1384,7 @@ fn peer_signature_algorithm_mtls_server_sees_client() {
 fn signature_algorithm_used_server_default() {
     // BoringSSL only retains signature_algorithm_used during the handshake, so we
     // capture it from a HANDSHAKE_DONE info callback.
-    let captured = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let captured = std::sync::Arc::new(AtomicBool::new(false));
 
     let mut server_builder = Server::builder();
     {
@@ -1395,7 +1395,7 @@ fn signature_algorithm_used_server_default() {
                 if mode == SslInfoCallbackMode::HANDSHAKE_DONE {
                     if let Some(sa) = ssl.signature_algorithm_used() {
                         assert!(sa.name().is_some());
-                        captured_cb.store(true, std::sync::atomic::Ordering::SeqCst);
+                        captured_cb.store(true, Ordering::SeqCst);
                     }
                 }
             });
@@ -1404,7 +1404,7 @@ fn signature_algorithm_used_server_default() {
     let _ = server.client_with_root_ca().connect();
 
     assert!(
-        captured.load(std::sync::atomic::Ordering::SeqCst),
+        captured.load(Ordering::SeqCst),
         "server should observe signature_algorithm_used at HANDSHAKE_DONE",
     );
 }
@@ -1437,7 +1437,7 @@ fn signature_algorithm_used_mtls_client() {
     }
     let server = server_builder.build();
 
-    let captured = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let captured = std::sync::Arc::new(AtomicBool::new(false));
     let captured_cb = std::sync::Arc::clone(&captured);
 
     let mut client_builder = server.client_with_root_ca();
@@ -1455,14 +1455,14 @@ fn signature_algorithm_used_mtls_client() {
             if mode == SslInfoCallbackMode::HANDSHAKE_DONE {
                 if let Some(sa) = ssl.signature_algorithm_used() {
                     assert!(sa.name().is_some());
-                    captured_cb.store(true, std::sync::atomic::Ordering::SeqCst);
+                    captured_cb.store(true, Ordering::SeqCst);
                 }
             }
         });
     let _ = client_builder.connect();
 
     assert!(
-        captured.load(std::sync::atomic::Ordering::SeqCst),
+        captured.load(Ordering::SeqCst),
         "client should observe signature_algorithm_used at HANDSHAKE_DONE in mTLS",
     );
 }

--- a/boring/src/symm.rs
+++ b/boring/src/symm.rs
@@ -304,6 +304,7 @@ impl Cipher {
 
     /// Returns the cipher's NID.
     #[corresponds(EVP_CIPHER_nid)]
+    #[must_use]
     pub fn nid(&self) -> Nid {
         ffi::init();
         let nid = unsafe { ffi::EVP_CIPHER_nid(self.as_ptr()) };
@@ -774,9 +775,9 @@ mod tests {
     fn test_stream_cipher_output() {
         let key = [0u8; 16];
         let iv = [0u8; 16];
-        let mut c = super::Crypter::new(
-            super::Cipher::aes_128_ctr(),
-            super::Mode::Encrypt,
+        let mut c = Crypter::new(
+            Cipher::aes_128_ctr(),
+            Mode::Encrypt,
             &key,
             Some(&iv),
         )
@@ -804,29 +805,29 @@ mod tests {
             0x8eu8, 0xa2u8, 0xb7u8, 0xcau8, 0x51u8, 0x67u8, 0x45u8, 0xbfu8, 0xeau8, 0xfcu8, 0x49u8,
             0x90u8, 0x4bu8, 0x49u8, 0x60u8, 0x89u8,
         ];
-        let mut c = super::Crypter::new(
-            super::Cipher::aes_256_ecb(),
-            super::Mode::Encrypt,
+        let mut c = Crypter::new(
+            Cipher::aes_256_ecb(),
+            Mode::Encrypt,
             &k0,
             None,
         )
         .unwrap();
         c.pad(false);
-        let mut r0 = vec![0; c0.len() + super::Cipher::aes_256_ecb().block_size()];
+        let mut r0 = vec![0; c0.len() + Cipher::aes_256_ecb().block_size()];
         let count = c.update(&p0, &mut r0).unwrap();
         let rest = c.finalize(&mut r0[count..]).unwrap();
         r0.truncate(count + rest);
         assert_eq!(hex::encode(&r0), hex::encode(c0));
 
-        let mut c = super::Crypter::new(
-            super::Cipher::aes_256_ecb(),
-            super::Mode::Decrypt,
+        let mut c = Crypter::new(
+            Cipher::aes_256_ecb(),
+            Mode::Decrypt,
             &k0,
             None,
         )
         .unwrap();
         c.pad(false);
-        let mut p1 = vec![0; r0.len() + super::Cipher::aes_256_ecb().block_size()];
+        let mut p1 = vec![0; r0.len() + Cipher::aes_256_ecb().block_size()];
         let count = c.update(&r0, &mut p1).unwrap();
         let rest = c.finalize(&mut p1[count..]).unwrap();
         p1.truncate(count + rest);
@@ -848,15 +849,15 @@ mod tests {
             0x4a_u8, 0x2e_u8, 0xe5_u8, 0x6_u8, 0xbf_u8, 0xcf_u8, 0xf2_u8, 0xd7_u8, 0xea_u8,
             0x2d_u8, 0xb1_u8, 0x85_u8, 0x6c_u8, 0x93_u8, 0x65_u8, 0x6f_u8,
         ];
-        let mut cr = super::Crypter::new(
-            super::Cipher::aes_256_cbc(),
-            super::Mode::Decrypt,
+        let mut cr = Crypter::new(
+            Cipher::aes_256_cbc(),
+            Mode::Decrypt,
             &data,
             Some(&iv),
         )
         .unwrap();
         cr.pad(false);
-        let mut unciphered_data = vec![0; data.len() + super::Cipher::aes_256_cbc().block_size()];
+        let mut unciphered_data = vec![0; data.len() + Cipher::aes_256_cbc().block_size()];
         let count = cr.update(&ciphered_data, &mut unciphered_data).unwrap();
         let rest = cr.finalize(&mut unciphered_data[count..]).unwrap();
         unciphered_data.truncate(count + rest);
@@ -866,13 +867,13 @@ mod tests {
         assert_eq!(&unciphered_data, expected_unciphered_data);
     }
 
-    fn cipher_test(ciphertype: super::Cipher, pt: &str, ct: &str, key: &str, iv: &str) {
+    fn cipher_test(ciphertype: Cipher, pt: &str, ct: &str, key: &str, iv: &str) {
         let pt = Vec::from_hex(pt).unwrap();
         let ct = Vec::from_hex(ct).unwrap();
         let key = Vec::from_hex(key).unwrap();
         let iv = Vec::from_hex(iv).unwrap();
 
-        let computed = super::decrypt(ciphertype, &key, Some(&iv), &ct).unwrap();
+        let computed = decrypt(ciphertype, &key, Some(&iv), &ct).unwrap();
         let expected = pt;
 
         if computed != expected {
@@ -896,7 +897,7 @@ mod tests {
         let key = "97CD440324DA5FD1F7955C1C13B6B466";
         let iv = "";
 
-        cipher_test(super::Cipher::rc4(), pt, ct, key, iv);
+        cipher_test(Cipher::rc4(), pt, ct, key, iv);
     }
 
     #[test]
@@ -908,7 +909,7 @@ mod tests {
         let key = "2B7E151628AED2A6ABF7158809CF4F3C";
         let iv = "F0F1F2F3F4F5F6F7F8F9FAFBFCFDFEFF";
 
-        cipher_test(super::Cipher::aes_128_ctr(), pt, ct, key, iv);
+        cipher_test(Cipher::aes_128_ctr(), pt, ct, key, iv);
     }
 
     #[test]
@@ -920,7 +921,7 @@ mod tests {
         let key = "2b7e151628aed2a6abf7158809cf4f3c";
         let iv = "000102030405060708090a0b0c0d0e0f";
 
-        cipher_test(super::Cipher::aes_128_ofb(), pt, ct, key, iv);
+        cipher_test(Cipher::aes_128_ofb(), pt, ct, key, iv);
     }
 
     #[test]
@@ -932,7 +933,7 @@ mod tests {
         let key = "8e73b0f7da0e6452c810f32b809079e562f8ead2522c6b7b";
         let iv = "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff";
 
-        cipher_test(super::Cipher::aes_192_ctr(), pt, ct, key, iv);
+        cipher_test(Cipher::aes_192_ctr(), pt, ct, key, iv);
     }
 
     #[test]
@@ -944,7 +945,7 @@ mod tests {
         let key = "8e73b0f7da0e6452c810f32b809079e562f8ead2522c6b7b";
         let iv = "000102030405060708090a0b0c0d0e0f";
 
-        cipher_test(super::Cipher::aes_192_ofb(), pt, ct, key, iv);
+        cipher_test(Cipher::aes_192_ofb(), pt, ct, key, iv);
     }
 
     #[test]
@@ -956,7 +957,7 @@ mod tests {
         let key = "603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4";
         let iv = "000102030405060708090a0b0c0d0e0f";
 
-        cipher_test(super::Cipher::aes_256_ofb(), pt, ct, key, iv);
+        cipher_test(Cipher::aes_256_ofb(), pt, ct, key, iv);
     }
 
     #[test]
@@ -966,7 +967,7 @@ mod tests {
         let key = "7cb66337f3d3c0fe";
         let iv = "0001020304050607";
 
-        cipher_test(super::Cipher::des_cbc(), pt, ct, key, iv);
+        cipher_test(Cipher::des_cbc(), pt, ct, key, iv);
     }
 
     #[test]
@@ -976,7 +977,7 @@ mod tests {
         let key = "7cb66337f3d3c0fe";
         let iv = "0001020304050607";
 
-        cipher_test(super::Cipher::des_ecb(), pt, ct, key, iv);
+        cipher_test(Cipher::des_ecb(), pt, ct, key, iv);
     }
 
     #[test]
@@ -986,7 +987,7 @@ mod tests {
         let key = "010203040506070801020304050607080102030405060708";
         let iv = "5cc118306dc702e4";
 
-        cipher_test(super::Cipher::des_ede3(), pt, ct, key, iv);
+        cipher_test(Cipher::des_ede3(), pt, ct, key, iv);
     }
 
     #[test]
@@ -996,7 +997,7 @@ mod tests {
         let key = "7cb66337f3d3c0fe7cb66337f3d3c0fe7cb66337f3d3c0fe";
         let iv = "0001020304050607";
 
-        cipher_test(super::Cipher::des_ede3_cbc(), pt, ct, key, iv);
+        cipher_test(Cipher::des_ede3_cbc(), pt, ct, key, iv);
     }
 
     #[test]
@@ -1065,7 +1066,7 @@ mod tests {
             Cipher::rc4(),
         ] {
             let name = cipher.nid().short_name().unwrap_or("unknown");
-            assert_eq!(Cipher::from_nid(cipher.nid()), Some(cipher), "{}", name);
+            assert_eq!(Cipher::from_nid(cipher.nid()), Some(cipher), "{name}");
         }
 
         assert_eq!(Cipher::from_nid(Cipher::des_ede3().nid()), None);
@@ -1162,7 +1163,7 @@ mod tests {
             },
         ] {
             let name = t.cipher.nid().short_name().unwrap_or("unknown");
-            assert_eq!(t.cipher.nid().as_raw(), t.nid, "{}", name);
+            assert_eq!(t.cipher.nid().as_raw(), t.nid, "{name}");
         }
     }
 }


### PR DESCRIPTION
Rust started warning about incompatible redefinitions of `malloc`.

Boring headers pull in C stdlib, and `bindgen` isn't very good at filtering out its unused/irrelevant symbols.

This change excludes about 3000 lines of boilerplate from the bindings. I couldn't simply exclude `__.*`, because macOS uses a pattern of `time_t = __darwin_time_t`, and bindgen would naively leave it broken instead of following the aliases.